### PR TITLE
Tickets/preops 627

### DIFF
--- a/03b_Image_Display_with_Firefly.ipynb
+++ b/03b_Image_Display_with_Firefly.ipynb
@@ -169,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "afw_display.setMaskTransparency(100)"
+    "afw_display.setMaskTransparency(80)"
    ]
   },
   {
@@ -446,7 +446,7 @@
     "* [Getting Started on Image Display (pipelines.lsst.io)](https://pipelines.lsst.io/getting-started/display.html)\n",
     "\n",
     "* [afw.display Doxygen website](http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/namespacelsst_1_1afw_1_1display.html)  \n",
-    "* [afw.display GitHub website](https://github.com/RobertLuptonTheGood/afw/tree/master/python/lsst/afw/display)  \n"
+    "* [afw.display GitHub website](https://github.com/lsst/afw/tree/master/python/lsst/afw/display)  \n"
    ]
   },
   {


### PR DESCRIPTION
First draft of Firefly image display notebook. My biggest question is whether we should keep both the calexp and deepCoadd_calexp display portions, or just include a single dataset type (deepCoadd_calexp) for simplicity.