### PR TITLE
Fix typo in TAP sample query.

### DIFF
--- a/02_Intermediate_TAP_Query.ipynb
+++ b/02_Intermediate_TAP_Query.ipynb
@@ -356,8 +356,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "query = \"SELECT ra, dec, mag_g, mag_i \" \\\n",
-    "        \"mag_i, mag_g_cModel, mag_r_cModel, mag_i_cModel, \" \\\n",
+    "query = \"SELECT ra, dec, \" \\\n",
+    "        \"mag_g, mag_r, mag_i, \" \\\n",
+    "        \"mag_g_cModel, mag_r_cModel, mag_i_cModel, \" \\\n",
     "        \"psFlux_g, psFlux_r, psFlux_i, \" \\\n",
     "        \"cModelFlux_g, cModelFlux_r, cModelFlux_i, \" \\\n",
     "        \"tract, patch, extendedness, good, clean \" \\\n",


### PR DESCRIPTION
"mag_g, mag_i mag_i, mag_g_cModel" -> "mag_g, mag_r, mag_i, mag_g_cModel"

This wasn't caught because
a. The Notebook just tests for number of rows returned.
b. The query interpreter apparently accepts "mag_g, mag_i mag_i, mag_g_cModel" -> "mag_g, mag_i, mag_g_cModel" instead of throwing an error.

Reflow query to make the structure more obvious.