### PR TITLE
Tickets/PREOPS-1134

### DIFF
--- a/04a_Intro_to_Butler.ipynb
+++ b/04a_Intro_to_Butler.ipynb
@@ -1,0 +1,575 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
+    "<b>Introduction to Data Access with the Butler</b> <br>\n",
+    "Contact author(s): Alex Drlica-Wagner <br>\n",
+    "Last verified to run: 2022-06-24 <br>\n",
+    "LSST Science Piplines version: Weekly 2022_22 <br>\n",
+    "Container Size: medium <br>\n",
+    "Targeted learning level: beginner <br>"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "%load_ext pycodestyle_magic\n",
+    "%flake8_on\n",
+    "import logging\n",
+    "logging.getLogger(\"flake8\").setLevel(logging.FATAL)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Description:** This notebook uses the Butler to query DP0 images and catalogs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Skills:** Query and retrieve images and catalog data with the Butler."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**LSST Data Products:** Images (calexp, goodSeeingDiff_differenceExp, deepCoadd) and catalogs (sourceTable, diaSourceTable, objectTable, forcedSourceTable, forcedSourceOnDiaObjectTable)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Packages:** lsst.daf.butler"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Credit:** This tutorial was originally developed by Alex Drlica-Wagner. Please consider acknowledging him in any publications or software releases that make use of this notebook's contents."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Get Support:**\n",
+    "Find DP0-related documentation and resources at <a href=\"https://dp0-2.lsst.io\">dp0-2.lsst.io</a>. Questions are welcome as new topics in the <a href=\"https://community.lsst.org/c/support/dp0\">Support - Data Preview 0 Category</a> of the Rubin Community Forum. Rubin staff will respond to all questions posted there."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Introduction\n",
+    "\n",
+    "The Butler is the LSST Science Pipelines interface for managing, reading, and writing datasets. The Butler can be used to explore the contents of the DP0 data repository and access the DP0 data. The current version of the Butler (referred to as \"Gen-3\") is still under development, and this notebook may be modified in the future. Full Butler documentation can be found [here](https://pipelines.lsst.io/modules/lsst.daf.butler/index.html).\n",
+    "\n",
+    "This notebook demonstrates how to:<br>\n",
+    "1. Create an instance of the Butler<br>\n",
+    "2. Use the butler to retrieve image data<br>\n",
+    "3. Use the Butler to retrieve catalog data<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.1 Package Imports"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import general python packages and several packages from the LSST Science Pipelines, including the Butler package and AFW Display, which will be used to display images.\n",
+    "More details and techniques regarding image display with `AFW Display` can be found in the `rubin-dp0` GitHub Organization's [tutorial-notebooks](https://github.com/rubin-dp0/tutorial-notebooks) repository."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generic python packages\n",
+    "import pylab as plt\n",
+    "\n",
+    "# LSST Science Pipelines (Stack) packages\n",
+    "import lsst.daf.butler as dafButler\n",
+    "import lsst.afw.display as afwDisplay\n",
+    "\n",
+    "# Set a standard figure size to use\n",
+    "plt.rcParams['figure.figsize'] = (8.0, 8.0)\n",
+    "afwDisplay.setDefaultBackend('matplotlib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Create an instance of the Butler\n",
+    "\n",
+    "To create the Butler, we need to provide it with a configuration for the data set (often referred to as a \"data repository\").\n",
+    "This configuration can be the path to a yaml file (often named `butler.yaml`), a directory path (in which case the Butler will look for a `butler.yaml` file in that directory), a shorthand repository label (i.e., `dp02`). If no configuration is passed, the Butler will use a default value (this is not recommended in most cases).\n",
+    "For the purposes of accessing the DP0.2 data, we will use the `dp02` label.\n",
+    "\n",
+    "In addition, to the config, the Butler also takes a set of data `collections`. \n",
+    "Collections are lightweight groups of self-consistent datasets such as raw images, calibration files, reference catalogs, and the outputs of a processing runs.\n",
+    "You can find out more about collections [here](https://pipelines.lsst.io/v/weekly/modules/lsst.daf.butler/organizing.html#collections).\n",
+    "For the purposes of accessing the DP0.2 data, we will use the `2.2i/runs/DP0.2` collection. \n",
+    "Here, '2.2i' refers to the imSim run that was used to generated the simulated data and 'runs' refers to the fact that it is processed data.\n",
+    "\n",
+    "Lets instantiate a Butler pointing at the DP0.2 dataset..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an instance of the Butler pointing to the DP0.2 repository\n",
+    "config = 'dp02'\n",
+    "collections = '2.2i/runs/DP0.2'\n",
+    "butler = dafButler.Butler(config=config, collections=collections)\n",
+    "\n",
+    "# Note: This will trigger a warning from CFITSIO in w_2022_22.\n",
+    "# This warning can be safely ignored and will be corrected in the future."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can access more information through its help string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Learn more about the butler by uncommenting the following line.\n",
+    "# help(butler)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Butler image access\n",
+    "\n",
+    "The Butler can be used to access DP0 image data products. The DP0.2 [Data Products Definition Document (DPDD)](https://dp0-2.lsst.io/data-products-dp0-2/index.html#images) describes three different types of image data products: processed visit images (PVIs; `calexp`),  difference images (`goodSeeingDiff_differenceExp`), and coadded images (`deepCoadd`). We will demonstrate how to access each of these.\n",
+    "\n",
+    "In order to access a data product through the Butler, we will need to tell the butler what data we want to access. This call generally has two components: the `datasetType` tells the butler what type of data product we are seeking (), and the `dataId` is a dictionary-like identifier for a specific  data product (more info on dataIds can be found [here](https://pipelines.lsst.io/v/weekly/modules/lsst.daf.butler/dimensions.html#data-ids))."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.1 Accessing Processed Visit Images\n",
+    "\n",
+    "Processed visit images can be accessed with the `calexp` datasetType. \n",
+    "These are image data products derived from processing of a single detector in a single visit of the LSST Camera. \n",
+    "To access a `calexp`, the minimal information that we will need to provide is the visit number and the detector number. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasetType = 'calexp'\n",
+    "dataId = {'visit': 192350, 'detector': 175}\n",
+    "calexp = butler.get(datasetType, dataId=dataId)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To view all parameters that can be passed to the dataId for calexp, we can use the butler registry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(next(butler.registry.queryDatasetTypes(datasetType)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot a calexp\n",
+    "fig = plt.figure()\n",
+    "display = afwDisplay.Display(frame=fig)\n",
+    "display.scale('asinh', 'zscale')\n",
+    "display.mtv(calexp.image)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.2 Accessing a Difference Image\n",
+    "\n",
+    "Difference images can be accessed with the `goodSeeingDiff_differenceExp` datasetType. \n",
+    "These are PVIs which have had a template image subtracted from them. \n",
+    "These data products are used to measure time-varying difference in the fluxes of astronomical sources.\n",
+    "To access a difference image we require the visit and detector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasetType = 'goodSeeingDiff_differenceExp'\n",
+    "dataId = {'visit': 192350, 'detector': 175}\n",
+    "diffexp = butler.get(datasetType, dataId=dataId)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot a goodSeeingDiff_differenceExp\n",
+    "fig = plt.figure()\n",
+    "display = afwDisplay.Display(frame=fig)\n",
+    "display.scale('asinh', 'zscale')\n",
+    "display.mtv(diffexp.image)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 3.3 Accessing a Coadd Images\n",
+    "\n",
+    "Coadded images combine multiple PVIs to assemble a deeper image; they can be accessed with the `deepCoadd` datasetType.\n",
+    "Coadd images are divided into “tracts” (a spherical convex polygon) and tracts are divided into “patches” (a quadrilateral sub-region, with a size in pixels chosen to fit easily into memory on desktop computers). \n",
+    "Coadd patches are roughly the same size as a `calexp`.\n",
+    "To access a `deepCoadd`, we need to specify the tract, patch, and band that we are interested in."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Access a deepCoadd\n",
+    "datasetType = 'deepCoadd'\n",
+    "dataId = {'tract': 4431, 'patch': 17, 'band': 'i'}\n",
+    "coadd = butler.get(datasetType, dataId=dataId)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot a deepCoadd\n",
+    "fig = plt.figure()\n",
+    "display = afwDisplay.Display(frame=fig)\n",
+    "display.scale('asinh', 'zscale')\n",
+    "display.mtv(coadd.image)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### 4. Butler table access\n",
+    "\n",
+    "While the preferred technique to access DP0 catalogs is through the table access protocol (TAP) service, the Butler can also provide access to these data products. \n",
+    "We will demonstrate how to access several different [catalog products described in the DPDD](https://dp0-2.lsst.io/data-products-dp0-2/index.html#catalogs). \n",
+    "The catalogs are returned by the Butler as pandas DataFrame objects, which can be further manipulated by the user.\n",
+    "The full descriptions of the column schema from the DP0.2 tables can be found [here](https://dm.lsst.org/sdm_schemas/browser/dp02.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 4.1 Accessing Processed Visit Sources\n",
+    "\n",
+    "The `sourceTable` provides astrometric and photometric measurements for sources detected in the individual PVIs (`calexp`). \n",
+    "Thus, to access the `sourceTable` for a specific PVI, we require similar information as was used to access the `calexp`.\n",
+    "More information on the columns of the `sourceTable` can be found [here](https://dm.lsst.org/sdm_schemas/browser/dp02.html#Source)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasetType = 'sourceTable'\n",
+    "dataId = {'visit': 192350, 'detector': 175}\n",
+    "src = butler.get(datasetType, dataId=dataId)\n",
+    "print(f\"Retrieved catalog of {len(src)} sources.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display sources\n",
+    "src"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### 4.2 Accessing Difference Image Sources\n",
+    "\n",
+    "The `diaSourceTable` provides astrometric and photometric measurements for sources detected in the difference images. \n",
+    "To access the `diaSourceTable` for a specific difference image, we require similar information as was used to access the difference image itself.\n",
+    "However, the `diaSourceTable` groups together all sources detected in a single visit, and thus the detector number is not used.\n",
+    "More information on the columns of the `diaSourceTable` can be found [here](https://dm.lsst.org/sdm_schemas/browser/dp02.html#DiaSource)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasetType = 'diaSourceTable'\n",
+    "dataId = {'visit': 192350}\n",
+    "dia_src = butler.get(datasetType, dataId=dataId)\n",
+    "print(f\"Retrieved catalog of {len(dia_src)} DIA sources.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display DIA sources\n",
+    "dia_src"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To retrieve sources from a specific detector, we can select a subset of the sources returned by our query to the `diaSourceTable`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "visit = dataId['visit']\n",
+    "detector = 175\n",
+    "ccd_visit_id = int(f'{visit}' + f'{detector:03d}')\n",
+    "selection = dia_src['ccdVisitId'] == ccd_visit_id\n",
+    "dia_src_ccd = dia_src[selection]\n",
+    "print(f\"Found catalog of {len(dia_src_ccd)} DIA sources in visit,detector = {visit},{detector}.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 4.3 Accessing Coadd Objects\n",
+    "\n",
+    "The `objectTable` provides astrometric and photometric measurements for objects detected in coadded images. \n",
+    "These objects are assembled across the set of coadd images in all bands, and thus contain multi-band photometry. \n",
+    "For this reason, we do not specify the band in the `dataId`.\n",
+    "More information on the columns of the `objectTable` can be found [here](https://dm.lsst.org/sdm_schemas/browser/dp02.html#Object)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Access objects associated with a coadd\n",
+    "datasetType = 'objectTable'\n",
+    "dataId = {'tract': 4431, 'patch': 17}\n",
+    "obj = butler.get(datasetType, dataId=dataId)\n",
+    "print(f\"Retrieved catalog of {len(obj)} objects.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display objects\n",
+    "obj"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 4.4 Acessing Difference Image Objects\n",
+    "\n",
+    "The  contains derived summary parameters for DIA sources associated by sky location and includes lighcurve statistics (e.g., flux chi2, Stetson J).\n",
+    "The DIA objects can be accessed from the `diaObjectTable_tract` table. \n",
+    "As implied by the table name, it is intended to be queried by coadd tract.\n",
+    "More information on the `diaObjectTable_tract` can be found [here](https://dm.lsst.org/sdm_schemas/browser/dp02.html#DiaObject)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Access DIA objects\n",
+    "datasetType = 'diaObjectTable_tract'\n",
+    "dataId = {'tract': 4431}\n",
+    "dia_obj = butler.get(datasetType, dataId=dataId)\n",
+    "print(f\"Retrieved catalog of {len(dia_obj)} DIA objects.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display DIA objects\n",
+    "dia_obj"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### 4.5 Accessing Forced Photometry Sources\n",
+    "\n",
+    "Forced photometry refers to the process of fitting for a source at a specific location in an image regardless of whether the source has been detected in that image. \n",
+    "This is useful when objects are not detected in all bands (i.e., drop outs) or observations (i.e., transient or variable objects). \n",
+    "The `forcedSourceTable` contains forced photometry performed on the individual PVIs at the locations of all detected objects and linked to the `objectTable`.\n",
+    "In contrast, the `forcedSourceOnDiaObjectTable` contains forced photometry on the individual PVIs at the locations of all objects in the `diaObjectTable`.\n",
+    "Note that the tables returned by these butler queries are quite large and can fill up the memory available to your notebook.\n",
+    "\n",
+    "More information on the columns of the `forcedSourceTable` can be found [here](https://dm.lsst.org/sdm_schemas/browser/dp02.html#ForcedSource), while more information on `forcedSourceOnDiaObjectTable` can be found [here](https://dm.lsst.org/sdm_schemas/browser/dp02.html#ForcedSourceOnDiaObject)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasetType = 'forcedSourceTable'\n",
+    "dataId = {'tract': 4431, 'patch': 16}\n",
+    "forced_src = butler.get(datasetType, dataId=dataId)\n",
+    "print(f\"Retrieved catalog of {len(forced_src)} forced sources.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display forced sources\n",
+    "forced_src"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasetType = 'forcedSourceOnDiaObjectTable'\n",
+    "dataId = {'tract': 4431, 'patch': 16}\n",
+    "dia_forced_src = butler.get(datasetType, dataId=dataId)\n",
+    "print(f\"Retrieved catalog of {len(dia_forced_src)} DIA forced sources.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display DIA forced sources\n",
+    "dia_forced_src"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5. Summary\n",
+    "\n",
+    "In this notebook we demonstrated Butler access for a set of image and catalog data products described in the [DPDD for DP0.2](https://dp0-2.lsst.io/data-products-dp0-2/index.html#dp0-2-data-products-definition-document-dpdd). \n",
+    "However, we have not demonstrated the powerful capability of the Butler to query the holdings of a data repository.\n",
+    "The full power of the Butler can be found in the [Butler documentation](https://pipelines.lsst.io/modules/lsst.daf.butler/index.html), and we expect that more advance Butler tutorial notebooks will be forthcoming."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/04a_Intro_to_Butler.ipynb
+++ b/04a_Intro_to_Butler.ipynb
@@ -14,16 +14,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
-    "%load_ext pycodestyle_magic\n",
-    "%flake8_on\n",
-    "import logging\n",
-    "logging.getLogger(\"flake8\").setLevel(logging.FATAL)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/04a_Intro_to_Butler.ipynb
+++ b/04a_Intro_to_Butler.ipynb
@@ -110,10 +110,10 @@
     "## 2. Create an instance of the Butler\n",
     "\n",
     "To create the Butler, we need to provide it with a configuration for the data set (often referred to as a \"data repository\").\n",
-    "This configuration can be the path to a yaml file (often named `butler.yaml`), a directory path (in which case the Butler will look for a `butler.yaml` file in that directory), a shorthand repository label (i.e., `dp02`). If no configuration is passed, the Butler will use a default value (this is not recommended in most cases).\n",
+    "This configuration can be the path to a yaml file (often named `butler.yaml`), a directory path (in which case the Butler will look for a `butler.yaml` file in that directory), or a shorthand repository label (i.e., `dp02`). If no configuration is passed, the Butler will use a default value (this is not recommended in most cases).\n",
     "For the purposes of accessing the DP0.2 data, we will use the `dp02` label.\n",
     "\n",
-    "In addition, to the config, the Butler also takes a set of data `collections`. \n",
+    "In addition to the config, the Butler also takes a set of data `collections`. \n",
     "Collections are lightweight groups of self-consistent datasets such as raw images, calibration files, reference catalogs, and the outputs of a processing runs.\n",
     "You can find out more about collections [here](https://pipelines.lsst.io/v/weekly/modules/lsst.daf.butler/organizing.html#collections).\n",
     "For the purposes of accessing the DP0.2 data, we will use the `2.2i/runs/DP0.2` collection. \n",
@@ -158,18 +158,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3. Butler image access\n",
+    "## 3. Butler image access\n",
     "\n",
     "The Butler can be used to access DP0 image data products. The DP0.2 [Data Products Definition Document (DPDD)](https://dp0-2.lsst.io/data-products-dp0-2/index.html#images) describes three different types of image data products: processed visit images (PVIs; `calexp`),  difference images (`goodSeeingDiff_differenceExp`), and coadded images (`deepCoadd`). We will demonstrate how to access each of these.\n",
     "\n",
-    "In order to access a data product through the Butler, we will need to tell the butler what data we want to access. This call generally has two components: the `datasetType` tells the butler what type of data product we are seeking (), and the `dataId` is a dictionary-like identifier for a specific  data product (more info on dataIds can be found [here](https://pipelines.lsst.io/v/weekly/modules/lsst.daf.butler/dimensions.html#data-ids))."
+    "In order to access a data product through the Butler, we will need to tell the butler what data we want to access. This call generally has two components: the `datasetType` tells the butler what type of data product we are seeking (e.g., `deepCoadd`, `calexp`, `objectTable`), and the `dataId` is a dictionary-like identifier for a specific data product (more info on dataIds can be found [here](https://pipelines.lsst.io/v/weekly/modules/lsst.daf.butler/dimensions.html#data-ids))."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 3.1 Accessing Processed Visit Images\n",
+    "### 3.1 Accessing Processed Visit Images\n",
     "\n",
     "Processed visit images can be accessed with the `calexp` datasetType. \n",
     "These are image data products derived from processing of a single detector in a single visit of the LSST Camera. \n",
@@ -221,7 +221,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 3.2 Accessing a Difference Image\n",
+    "### 3.2 Accessing a Difference Image\n",
     "\n",
     "Difference images can be accessed with the `goodSeeingDiff_differenceExp` datasetType. \n",
     "These are PVIs which have had a template image subtracted from them. \n",
@@ -258,7 +258,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 3.3 Accessing a Coadd Images\n",
+    "### 3.3 Accessing a Coadd Images\n",
     "\n",
     "Coadded images combine multiple PVIs to assemble a deeper image; they can be accessed with the `deepCoadd` datasetType.\n",
     "Coadd images are divided into “tracts” (a spherical convex polygon) and tracts are divided into “patches” (a quadrilateral sub-region, with a size in pixels chosen to fit easily into memory on desktop computers). \n",
@@ -300,7 +300,7 @@
     "tags": []
    },
    "source": [
-    "### 4. Butler table access\n",
+    "## 4. Butler table access\n",
     "\n",
     "While the preferred technique to access DP0 catalogs is through the table access protocol (TAP) service, the Butler can also provide access to these data products. \n",
     "We will demonstrate how to access several different [catalog products described in the DPDD](https://dp0-2.lsst.io/data-products-dp0-2/index.html#catalogs). \n",
@@ -312,7 +312,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 4.1 Accessing Processed Visit Sources\n",
+    "### 4.1 Accessing Processed Visit Sources\n",
     "\n",
     "The `sourceTable` provides astrometric and photometric measurements for sources detected in the individual PVIs (`calexp`). \n",
     "Thus, to access the `sourceTable` for a specific PVI, we require similar information as was used to access the `calexp`.\n",
@@ -347,7 +347,7 @@
     "tags": []
    },
    "source": [
-    "#### 4.2 Accessing Difference Image Sources\n",
+    "### 4.2 Accessing Difference Image Sources\n",
     "\n",
     "The `diaSourceTable` provides astrometric and photometric measurements for sources detected in the difference images. \n",
     "To access the `diaSourceTable` for a specific difference image, we require similar information as was used to access the difference image itself.\n",
@@ -402,7 +402,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 4.3 Accessing Coadd Objects\n",
+    "### 4.3 Accessing Coadd Objects\n",
     "\n",
     "The `objectTable` provides astrometric and photometric measurements for objects detected in coadded images. \n",
     "These objects are assembled across the set of coadd images in all bands, and thus contain multi-band photometry. \n",
@@ -437,9 +437,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 4.4 Acessing Difference Image Objects\n",
+    "### 4.4 Acessing Difference Image Objects\n",
     "\n",
-    "The  contains derived summary parameters for DIA sources associated by sky location and includes lighcurve statistics (e.g., flux chi2, Stetson J).\n",
+    "The `diaObjectTable` contains derived summary parameters for DIA sources associated by sky location and includes lighcurve statistics (e.g., flux chi2, Stetson J).\n",
     "The DIA objects can be accessed from the `diaObjectTable_tract` table. \n",
     "As implied by the table name, it is intended to be queried by coadd tract.\n",
     "More information on the `diaObjectTable_tract` can be found [here](https://dm.lsst.org/sdm_schemas/browser/dp02.html#DiaObject)."
@@ -474,7 +474,7 @@
     "tags": []
    },
    "source": [
-    "#### 4.5 Accessing Forced Photometry Sources\n",
+    "### 4.5 Accessing Forced Photometry Sources\n",
     "\n",
     "Forced photometry refers to the process of fitting for a source at a specific location in an image regardless of whether the source has been detected in that image. \n",
     "This is useful when objects are not detected in all bands (i.e., drop outs) or observations (i.e., transient or variable objects). \n",
@@ -533,12 +533,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 5. Summary\n",
+    "## 5. Summary\n",
     "\n",
     "In this notebook we demonstrated Butler access for a set of image and catalog data products described in the [DPDD for DP0.2](https://dp0-2.lsst.io/data-products-dp0-2/index.html#dp0-2-data-products-definition-document-dpdd). \n",
     "However, we have not demonstrated the powerful capability of the Butler to query the holdings of a data repository.\n",
-    "The full power of the Butler can be found in the [Butler documentation](https://pipelines.lsst.io/modules/lsst.daf.butler/index.html), and we expect that more advance Butler tutorial notebooks will be forthcoming."
+    "The full power of the Butler can be found in the [Butler documentation](https://pipelines.lsst.io/modules/lsst.daf.butler/index.html).\n",
+    "More advanced Butler tutorial notebooks will be forthcoming."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This is a complete rewrite of the Butler intro notebook with a focus on using the Butler to access the data products described in the [DP0.2 DPDD](https://dp0-2.lsst.io/v/PREOPS-1232/data-products-dp0-2/index.html#dp0-2-data-products-definition-document-dpdd). Butler investigation of repository contents and Butler dataset queries are deferred to future notebooks.