### PR TITLE
Updates after DP02 delegate assembly

### DIFF
--- a/03a_Image_Display_and_Manipulation.ipynb
+++ b/03a_Image_Display_and_Manipulation.ipynb
@@ -7,7 +7,7 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<b>Image Display and Manipulation</b> <br>\n",
     "Contact authors: Alex Drlica-Wagner, Jeff Carlin <br>\n",
-    "Last verified to run: 2022-06-27 <br>\n",
+    "Last verified to run: 2022-08-10 <br>\n",
     "LSST Science Piplines version: Weekly 2022_22 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: beginner <br>"
@@ -92,7 +92,6 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import gc\n",
-    "import numpy as np\n",
     "\n",
     "# Astropy imports\n",
     "from astropy.wcs import WCS\n",
@@ -349,13 +348,20 @@
     "butler = Butler(config, collections=collection)\n",
     "\n",
     "# Specify the data that we are accessing\n",
-    "dataId = {'visit': 192350, 'detector': 175}\n",
+    "dataId = {'visit': 192350, 'detector': 175, 'band': 'i'}\n",
     "\n",
     "# Retrieve the data using the `butler` instance and its function `get()`\n",
     "calexp = butler.get('calexp', **dataId)\n",
     "\n",
     "# Note: This will trigger a warning from CFITSIO in w_2022_22.\n",
     "# This warning can be safely ignored and will be corrected in the future."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `calexp` that is retruned by the Butler in the previous cell is an `ExposureF` Python object. Exposures are powerful representations of image data because they contain not only the image data, but also a variance image for uncertainty propagation, a bit mask image, and key-value metadata. In the next section, we will use AFWDisplay to visualize the image and mask associated with this Exposure. More documentation on accessing and visualizing an Exposure be found [here](https://pipelines.lsst.io/getting-started/display.html)."
    ]
   },
   {
@@ -388,7 +394,7 @@
     "1. Create a `matplotlib.pyplot` figure using `plt.figure()` -- this will be familiar to anyone with experience using `matplotlib`.\n",
     "2. Create an alias to the `lsst.afw.display.Display` method that will allow us to display the data to the screen.  This alias will be called `display`.\n",
     "3. Before showing the data on the screen, we have to decide how to apply an image stretch given the data. The algorithm we'll use is `asinh` -- familiar from SDSS images -- with a range of values set by `zscale`. To do this, we use the `scale()` function provided by `lsst.afw.display`. See the `scale()` function definition in the [`interface.py` file of the lsst.afw.display library](https://github.com/lsst/afw/blob/master/python/lsst/afw/display/interface.py).\n",
-    "4. Finally, we can display the image. To do this, we provide the `mtv()` method the `image` member of our calibrated image retrieved by the `butler`. We can then use `plt.show()` to display our figure.\n",
+    "4. Finally, we can display the image. To do this, we provide the `mtv()` method the `calexp.image` member of our calibrated image retrieved by the `butler`. We can then use `plt.show()` to display our figure.\n",
     "5. After we are done creating and displaying the image, we remove the underlying data from memory.\n",
     "\n",
     "All these tasks are best done within the same notebook cell."
@@ -407,7 +413,7 @@
     "# set the image stretch algorithm and range\n",
     "display.scale('asinh', 'zscale')\n",
     "# load the image into the display\n",
-    "display.mtv(calexp)\n",
+    "display.mtv(calexp.image)\n",
     "# show the corresponding pyplot figure\n",
     "plt.show()\n",
     "# clean up memory\n",
@@ -468,9 +474,33 @@
    "source": [
     "### 3.2: Use AFWDisplay to Visualize the Image and Mask Plane\n",
     "\n",
-    "The `calexp` returned by the butler contains more than just the image pixel values (see the Stack Club [calexp tutorial](https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Basics/Calexp_guided_tour.ipynb) for more details). One other component is the mask plane associated with the image. A mask is composed of a set of \"mask planes,\" 2D binary bit maps corresponding to pixels that are masked for various reasons (see [here](https://pipelines.lsst.io/v/DM-11392/getting-started/display.html#interpreting-displayed-mask-colors) for more details).\n",
-    "\n",
-    "Let's start by plotting the image and mask plane side-by-side using matplotlib subplots."
+    "The `calexp` returned by the butler contains more than just the image pixel values (see the Stack Club [calexp tutorial](https://github.com/LSSTScienceCollaborations/StackClub/blob/master/Basics/Calexp_guided_tour.ipynb) for more details). One other component is the mask associated with the image. A mask is composed of a set of \"mask planes,\" 2D binary bit maps corresponding to pixels that are masked for various reasons (see [here](https://pipelines.lsst.io/v/DM-11392/getting-started/display.html#interpreting-displayed-mask-colors) for more details)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`afwDisplay` maps each bit in the mask plain to a specific display color. We can view this mapping using the code in the following cell. We can also use the `setMaskPlaneColor` method to change the colors that `afwDisplay` uses for each mask plane."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print the colors associated to each plane in the mask\n",
+    "print(\"Mask plane bit definitions:\\n\", display.getMaskPlaneColor())\n",
+    "print(\"\\nMask plane methods:\\n\")\n",
+    "help(display.setMaskPlaneColor)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's plot the image and mask plane side-by-side using matplotlib subplots."
    ]
   },
   {
@@ -496,7 +526,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`afwDisplay` also provides a nice interface for plotting the mask on top of the image by providing the `calexp.maskedImage`."
+    "`afwDisplay` also provides a nice interface for plotting the mask on top of the image by providing the `calexp.maskedImage`. The mask will also be plotted on top of the image if you pass the `calexp` itself to `mtv` (as is done later in this notebook)."
    ]
   },
   {
@@ -534,38 +564,19 @@
     "# create a matplotlib.pyplot figure\n",
     "fig, ax = plt.subplots()\n",
     "# get an alias to the lsst.afw.display.Display() method\n",
-    "afw_display = afwDisplay.Display(frame=fig)\n",
+    "display = afwDisplay.Display(frame=fig)\n",
     "# set the image stretch algorithm and range\n",
-    "afw_display.scale('asinh', 'zscale')\n",
+    "display.scale('asinh', 'zscale')\n",
     "# set the transparency of the mask plane (0%=opaque, 100%=transparent)\n",
-    "afw_display.setMaskTransparency(80)\n",
+    "display.setMaskTransparency(80)\n",
     "# set the color for a single plane in the mask\n",
-    "afw_display.setMaskPlaneColor('DETECTED', 'blue')\n",
+    "display.setMaskPlaneColor('DETECTED', 'blue')\n",
     "# load the image and mask plane into the display\n",
-    "afw_display.mtv(calexp)\n",
+    "display.mtv(calexp)\n",
     "# show the corresponding pyplot figure\n",
     "plt.show()\n",
     "# clean up memory\n",
     "remove_figure(fig)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The `afw_display` object contains more information about the mask planes that can be accessed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Print the colors associated to each plane in the mask\n",
-    "print(\"Mask plane bit definitions:\\n\", afw_display.getMaskPlaneColor())\n",
-    "print(\"\\nMask plane methods:\\n\")\n",
-    "help(afw_display.setMaskPlaneColor)"
    ]
   },
   {
@@ -724,7 +735,7 @@
    "outputs": [],
    "source": [
     "# Select a position at roughly the center of the galaxy cluster:\n",
-    "cutout_image = cutout_coadd(butler, ra, dec, datasetType='deepCoadd',\n",
+    "cutout_image = cutout_coadd(butler, ra, dec, band='i', datasetType='deepCoadd',\n",
     "                            cutoutSideLength=501)\n",
     "print(\"The size of the cutout in pixels is: \", cutout_image.image.array.shape)"
    ]
@@ -736,9 +747,9 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
-    "afw_display = afwDisplay.Display(frame=fig)\n",
-    "afw_display.scale('asinh', 'zscale')\n",
-    "afw_display.mtv(cutout_image.image)\n",
+    "display = afwDisplay.Display(frame=fig)\n",
+    "display.scale('asinh', 'zscale')\n",
+    "display.mtv(cutout_image.image)\n",
     "plt.show()\n",
     "remove_figure(fig)"
    ]
@@ -797,7 +808,7 @@
    "outputs": [],
    "source": [
     "cutout_bbox = cutout_image.getBBox()\n",
-    "sel = cutout_bbox.contains(coadd_obj.x,coadd_obj.y)\n",
+    "sel = cutout_bbox.contains(coadd_obj.x, coadd_obj.y)\n",
     "cutout_obj = coadd_obj.loc[sel]"
    ]
   },
@@ -809,16 +820,16 @@
    "source": [
     "# Display the image cutout\n",
     "fig, ax = plt.subplots()\n",
-    "afw_display = afwDisplay.Display(frame=fig)\n",
-    "afw_display.scale('asinh', 'zscale')\n",
-    "afw_display.mtv(cutout_image.image)\n",
+    "display = afwDisplay.Display(frame=fig)\n",
+    "display.scale('asinh', 'zscale')\n",
+    "display.mtv(cutout_image.image)\n",
     "\n",
     "# We use display buffering to avoid re-drawing the image\n",
     "#  after each source is plotted\n",
-    "with afw_display.Buffering():\n",
-    "    for i,s in cutout_obj.iterrows():\n",
-    "        afw_display.dot('+', s.x, s.y, ctype=afwDisplay.RED)\n",
-    "        afw_display.dot('o', s.x, s.y, size=20, ctype='orange')\n",
+    "with display.Buffering():\n",
+    "    for i, s in cutout_obj.iterrows():\n",
+    "        display.dot('+', s.x, s.y, ctype=afwDisplay.RED)\n",
+    "        display.dot('o', s.x, s.y, size=20, ctype='orange')\n",
     "\n",
     "plt.show()\n",
     "remove_figure(fig)"


### PR DESCRIPTION
I've made changes to address the [JIRA comments](https://jira.lsstcorp.org/browse/PREOPS-1314) after the delegate assembly:

- I've added the description of the calexp to 2.0 (where it is first accessed) rather than 3.1 (which focuses on visualization)
- The keyword for the dataId is `band` rather than `filter`
- I've changed both the instructions and code cell to use calexp.image in 3.1 (previous we were displaying the calexp, which overlaid the mask plane)
- Moved the mask definitions to the beginning of 3.2
- Good catch on the r-band default of `cutout_coadd`. I figured it'd be good to keep looking at the same band that we were looking at for the calexp, so I've added an argument `band='i'` to the call to cutout_coadd.
- I've tried to standardize the display variable name to `display = afwDisplay.Display(...)`
- I've run flake8_nb again and made some modifications for consistency.