### PR TITLE
PREOPS-1465:  add html export to NBs 06a and/or 06b

### DIFF
--- a/06a_Interactive_Image_Visualization.ipynb
+++ b/06a_Interactive_Image_Visualization.ipynb
@@ -7,7 +7,7 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<b>Interactive Image Visualization</b> <br>\n",
     "Contact author(s): Leanne Guy <br>\n",
-    "Last verified to run: 2022-11-22 <br>\n",
+    "Last verified to run: 2022-12-21 <br>\n",
     "LSST Science Piplines version: Weekly 2022_40 <br>\n",
     "Container Size: large <br>\n",
     "Targeted learning level: intermediate <br>"
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Skills:** Visualize exposure images with Holoviews, interact with images with Holoviews Streams and Dynamic Map."
+    "**Skills:** Visualize exposure images with Holoviews, interact with images with Holoviews Streams and Dynamic Map, and output interactive images to interactive HTML files."
    ]
   },
   {
@@ -47,7 +47,8 @@
    "source": [
     "**Credit:**\n",
     "This tutorial was inspired by a notebook originally developed by Keith Bechtol in the context of the LSST Stack Club. \n",
-    "It has been updated and extended for DP0.1 and DP0.2 by Leanne Guy. "
+    "It has been updated and extended for DP0.1 and DP0.2 by Leanne Guy. Material on how to output an interactive HTML file \n",
+    "in Section 3.1 was added by Douglas Tucker."
    ]
   },
   {
@@ -89,6 +90,7 @@
    "outputs": [],
    "source": [
     "# General\n",
+    "import os\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
@@ -504,6 +506,63 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Finally, to close this section, we note that Holoviews permits one to output interactive images like the above to an HTML file, retaining most of the interactive qualities of the original image.  Thus, one can share an interactive image with colleagues without requiring them to run a Jupyter notebook.  We note that the interactivity of the HTML file is limited by the proceessing capabilities of relatively simple JavaScript; so not all the interactive functionality of the notebook version is necessarily supported in the HTML file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's output an interactive HTML file for the above interactive image.  We will output it to your home directory.  We will make use of the Holoviews `save` function to output the image to the HTML files."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, let's construct the output file name:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outputDir = os.path.expanduser('~')\n",
+    "outputFileBaseName = 'nb06a_plot1.html'\n",
+    "outputFile = os.path.join(outputDir, outputFileBaseName)\n",
+    "\n",
+    "print('The full pathname of the interactive HTML file will be '+outputFile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now output the interactive HTML file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.save(img, outputFile, backend='bokeh')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To view the interactive HTML file, navigate to it via the directory listing in the left-hand side panel of this Jupyter notebook graphical interface, and click on its name.  This will open another tab in which one can view the HTML file.  Since the figure is of an image, the file is fairly large file (c. 85MB); so it will take about 15 seconds to load.  Once loading is complete, click on the \"Trust HTML\" button at the top-left of the tab's window.  You should see an near-duplicate of the interactive image that we produced just above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 3.2. Overlay source detections on the calexp\n",
     "\n",
     "Now let's overlay the sources on this calexp image. We will use the Points Element for the detections to overlay."
@@ -676,15 +735,10 @@
     " \n",
     " 3. In Section 3.2, try extracting additional information about the Sources and adding it to the custom hover tool. For example, the corresponding RA/DEC or the PSF flux.\n",
     " \n",
-    " 4. Try using a different stream function to interact with the images in Section 3.3."
+    " 4. Try using a different stream function to interact with the images in Section 3.3.\n",
+    " \n",
+    " 5. Try outputting an interactive HTML file (like what was done at the end of Section 3.1) for the interactive images in Section 3.2 and 3.3.  How much of of the interactive functionality from the notebook version of these images carries over to the HTML files?  (N.B.:  the `box` functionality from Section 3.3 does not seem to be supported in an interactive HTML file.)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/06a_Interactive_Image_Visualization.ipynb
+++ b/06a_Interactive_Image_Visualization.ipynb
@@ -506,7 +506,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, to close this section, we note that Holoviews permits one to output interactive images like the above to an HTML file, retaining most of the interactive qualities of the original image.  Thus, one can share an interactive image with colleagues without requiring them to run a Jupyter notebook.  We note that the interactivity of the HTML file is limited by the proceessing capabilities of relatively simple JavaScript; so not all the interactive functionality of the notebook version is necessarily supported in the HTML file."
+    "### 3.2. Output interactive image to HTML file\n",
+    "\n",
+    "Holoviews permits one to output interactive images like the above to an HTML file, retaining most of the interactive qualities of the original image.\n",
+    "Thus, one can share an interactive image with colleagues without requiring them to run a Jupyter notebook.\n",
+    "We note that the interactivity of the HTML file is limited by the proceessing capabilities of relatively simple JavaScript; so not all the interactive functionality of the notebook version is necessarily supported in the HTML file."
    ]
   },
   {
@@ -556,14 +560,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To view the interactive HTML file, navigate to it via the directory listing in the left-hand side panel of this Jupyter notebook graphical interface, and click on its name.  This will open another tab in which one can view the HTML file.  Since the figure is of an image, the file is fairly large file (c. 85MB); so it will take about 15 seconds to load.  Once loading is complete, click on the \"Trust HTML\" button at the top-left of the tab's window.  You should see an near-duplicate of the interactive image that we produced just above."
+    "To view the interactive HTML file, navigate to it via the directory listing in the left-hand side panel of this Jupyter notebook graphical interface, and double-click on its name (or control-click or right-click on its name and select \"Open\").\n",
+    "\n",
+    "This will open another tab within JupyterLab, in which one can view the HTML file.\n",
+    "Since the figure is of an image, the file is fairly large file (about 85 MB), so it will take about 15 seconds to load.\n",
+    "Once loading is complete, click on the \"Trust HTML\" button at the top-left of the tab's window.\n",
+    "You should see an near-duplicate of the interactive image that we produced just above.\n",
+    "\n",
+    "You can also download the HTML file to your local computer (control-click or right-click on its name in the file browser at left and select \"Download\").\n",
+    "Then load it in a browser window on your local computer and interact with it the same way."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.2. Overlay source detections on the calexp\n",
+    "### 3.3. Overlay source detections on the calexp\n",
     "\n",
     "Now let's overlay the sources on this calexp image. We will use the Points Element for the detections to overlay."
    ]
@@ -629,7 +641,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.3. Interactive image exploration with Holoviews Streams and DynamicMap\n",
+    "### 3.4. Interactive image exploration with Holoviews Streams and DynamicMap\n",
     "\n",
     "Now let's add some interactive exploration capability using Holoviews [Streams](http://holoviews.org/user_guide/Streaming_Data.html) and [DynamicMap](https://holoviews.org/reference/containers/bokeh/DynamicMap.html). A DynamicMap is an explorable multi-dimensional wrapper around a callable that returns HoloViews objects. The core concept behind a stream is simple: it defines one or more parameters that can change over time that automatically refreshes code depending on those parameter values."
    ]
@@ -688,7 +700,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below is another version of the image with a [tap stream](http://holoviews.org/reference/streams/bokeh/Tap.html) instead of box select. A Tap stream allows you to click or 'tap' a position to interact with a plot. Try zooming in on an interesting part of the image and then 'tap' somewhere to place an 'X' marker.\n",
+    "Below is another version of the image with a [tap stream](http://holoviews.org/reference/streams/bokeh/Tap.html) instead of box select.\n",
+    "A Tap stream allows you to click or 'tap' a position to interact with a plot.\n",
+    "Try zooming in on an interesting part of the image generated below, and then 'tap' somewhere to place an 'X' marker.\n",
     "\n",
     "> **Notice:** The marker is white, and might be invisible if you select to mark a high-flux region."
    ]

--- a/06b_Interactive_Catalog_Visualization.ipynb
+++ b/06b_Interactive_Catalog_Visualization.ipynb
@@ -7,7 +7,7 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<b>Interactive Catalog Visualization</b> <br>\n",
     "Contact author(s): Leanne Guy <br>\n",
-    "Last verified to run: 2022-11-22 <br>\n",
+    "Last verified to run: 2022-12-21 <br>\n",
     "LSST Science Piplines version: Weekly 2022_40 <br>\n",
     "Container Size: large <br>\n",
     "Targeted learning level: intermediate <br>"
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Skills:** Create linked interactive plots for large datasets. Use Bokeh, HoloViews, and Datashader."
+    "**Skills:** Create linked interactive plots for large datasets, and output interactive plots to interactive HTML files. Use Bokeh, HoloViews, and Datashader."
    ]
   },
   {
@@ -94,6 +94,7 @@
    "outputs": [],
    "source": [
     "# General\n",
+    "import os\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
@@ -107,7 +108,7 @@
     "\n",
     "# Bokeh\n",
     "import bokeh\n",
-    "from bokeh.io import output_notebook, show\n",
+    "from bokeh.io import output_notebook, show, output_file, reset_output\n",
     "from bokeh.models import ColumnDataSource, Range1d, HoverTool\n",
     "from bokeh.models import CDSView, GroupFilter\n",
     "from bokeh.plotting import figure, gridplot\n",
@@ -749,6 +750,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note:  sometimes the `bokeh.io.show` function can be finicky when we switch output modes (e.g., from inline to an HTML file and back again); so we define the following two functions to avert a \"Models must be owned by only a single document\" error (see, e.g., <a href=\"https://github.com/bokeh/bokeh/issues/8579\">https://github.com/bokeh/bokeh/issues/8579</a>)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_bokeh_inline(p):\n",
+    "    try:\n",
+    "        reset_output()\n",
+    "        output_notebook()\n",
+    "        show(p)\n",
+    "    except:\n",
+    "        output_notebook()\n",
+    "        show(p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_bokeh_to_file(p, outputFile):\n",
+    "    try:\n",
+    "        reset_output()\n",
+    "        output_file(outputFile)\n",
+    "        show(p)\n",
+    "    except:\n",
+    "        output_file(outputFile)\n",
+    "        show(p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 4.1. Data preparation\n",
     "The basis for any data visualization is the underlying data. Getting the data preparation phase right is key to creating powerful visualizations. \n",
     "Bokeh works with a ColumnDataSource (CDS).  A CDS is essentially a collection of sequences of data that have their own unique column name. We will create a CDS from the data returned by the query above and pass it directly to Bokeh. The CDS is the core of bokeh plots. Bokeh automatically creates a CDS from data passed as python lists or numpy arrays.  CDS are useful as they allow data to be shared between multiple plots and renderers, enabling brushing and linking.\n",
@@ -894,7 +934,7 @@
    "outputs": [],
    "source": [
     "p = gridplot([[left, right]])\n",
-    "show(p)"
+    "show_bokeh_inline(p)"
    ]
   },
   {
@@ -904,6 +944,56 @@
     "Use the hover tool to see information about individual datapoints (e.g., the \"ObjectId\"). This information should appear automatically as you hover the mouse over the datapoints. Notice the data points highlighted in red on one panel with the hover tool are also highlighted on the other panel.\n",
     "\n",
     "Next, click on the selection box icon (with a \"+\" sign) or the selection lasso icon found in the upper right corner of the figure. Use the selection box and selection lasso to make various selections in either panel by clicking and dragging on either panel. The selected data points will be displayed in the other panel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, as we did in <a href=\"./06a_Interactive_OImage_Visualization.ipynb\">Tutorial Notebook 6a</a>, let's output this interactive plot to an interactive HTML file in your home directory.  Here, however, we will use the `bokeh.io.show` method, embedded in the `show_bokeh_to_file` function defined above, to perform the output."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, let's construct the output file name:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outputDir = os.path.expanduser('~')\n",
+    "outputFileName = 'nb06b_plot1.html'\n",
+    "outputFile = os.path.join(outputDir, outputFileName)\n",
+    "\n",
+    "print('The full pathname of the interactive HTML file will be '+outputFile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now output the interactive HTML file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_bokeh_to_file(p, outputFile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As in the <a href=\"./06a_Interactive_OImage_Visualization.ipynb\">Tutorial Notebook 6a</a>, to view the interactive HTML file, navigate to it via the directory listing in the left-hand side panel of this Jupyter notebook graphical interface, and click on its name.  This will open another tab in which one can view the HTML file.  Since it is relatively small (c. 3.6MB), the file should load quickly (within a few seconds).  Once loading is complete, click on the \"Trust HTML\" button at the top-left of the tab's window.  You should see an near-duplicate of the two linked plots that we produced just above."
    ]
   },
   {
@@ -1047,7 +1137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show(p)"
+    "show_bokeh_inline(p)"
    ]
   },
   {
@@ -1336,7 +1426,9 @@
     "\n",
     " 1. Holoviews works with a wide range of plotting libraries, Bokeh, matplotlib, plotly, mpld3, pygal to name a few. As an exercise, try changing the Holoviews plotting library to be `matplotlib` instead of `bokeh` at the beginning of the notebook with `hv.extension('matplotlib')`. You will see the holoviews + matplotlib icons displayed when the library is loaded successfully. Recreate a few plots and compare the outputs. Try again with some other plotting library. Don't forget to set the plotting library back to whichever you prefer to use for the rest of this tutorial. Note that some warnings might be raised.\n",
     "  \n",
-    " 2. Try writing a different callback function to use in Section 5.3. "
+    " 2. Try writing a different callback function to use in Section 5.3. \n",
+    " \n",
+    " 3. As with the plot in Section 4.2, try writing other interactive plots from this notebook to an interactive HTML file. Which ones can easily be output to an interactive HTML file?  Which HTML files show full interactive functionality?  Which ones don't? "
    ]
   }
  ],

--- a/06b_Interactive_Catalog_Visualization.ipynb
+++ b/06b_Interactive_Catalog_Visualization.ipynb
@@ -185,6 +185,47 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note:  sometimes the `bokeh.io.show` function can be finicky when we switch output modes (e.g., from inline to an HTML file and back again); so we define the following two functions to avert a \"Models must be owned by only a single document\" error (see, e.g., <a href=\"https://github.com/bokeh/bokeh/issues/8579\">https://github.com/bokeh/bokeh/issues/8579</a>).\n",
+    "\n",
+    "These functions are used in Section 4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_bokeh_inline(p):\n",
+    "    try:\n",
+    "        reset_output()\n",
+    "        output_notebook()\n",
+    "        show(p)\n",
+    "    except:\n",
+    "        output_notebook()\n",
+    "        show(p)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_bokeh_to_file(p, outputFile):\n",
+    "    try:\n",
+    "        reset_output()\n",
+    "        output_file(outputFile)\n",
+    "        show(p)\n",
+    "    except:\n",
+    "        output_file(outputFile)\n",
+    "        show(p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 2. Use the TAP service to obtain table data\n",
     "\n",
     "The basis for any data visualization is the underlying data. In this tutorial we will work with tabular data.\n",
@@ -750,45 +791,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note:  sometimes the `bokeh.io.show` function can be finicky when we switch output modes (e.g., from inline to an HTML file and back again); so we define the following two functions to avert a \"Models must be owned by only a single document\" error (see, e.g., <a href=\"https://github.com/bokeh/bokeh/issues/8579\">https://github.com/bokeh/bokeh/issues/8579</a>)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def show_bokeh_inline(p):\n",
-    "    try:\n",
-    "        reset_output()\n",
-    "        output_notebook()\n",
-    "        show(p)\n",
-    "    except:\n",
-    "        output_notebook()\n",
-    "        show(p)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def show_bokeh_to_file(p, outputFile):\n",
-    "    try:\n",
-    "        reset_output()\n",
-    "        output_file(outputFile)\n",
-    "        show(p)\n",
-    "    except:\n",
-    "        output_file(outputFile)\n",
-    "        show(p)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### 4.1. Data preparation\n",
     "The basis for any data visualization is the underlying data. Getting the data preparation phase right is key to creating powerful visualizations. \n",
     "Bokeh works with a ColumnDataSource (CDS).  A CDS is essentially a collection of sequences of data that have their own unique column name. We will create a CDS from the data returned by the query above and pass it directly to Bokeh. The CDS is the core of bokeh plots. Bokeh automatically creates a CDS from data passed as python lists or numpy arrays.  CDS are useful as they allow data to be shared between multiple plots and renderers, enabling brushing and linking.\n",
@@ -950,6 +952,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### 4.3. Output to interactive HTML file\n",
+    "\n",
     "Now, as we did in <a href=\"./06a_Interactive_OImage_Visualization.ipynb\">Tutorial Notebook 6a</a>, let's output this interactive plot to an interactive HTML file in your home directory.  Here, however, we will use the `bokeh.io.show` method, embedded in the `show_bokeh_to_file` function defined above, to perform the output."
    ]
   },
@@ -993,16 +997,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As in the <a href=\"./06a_Interactive_OImage_Visualization.ipynb\">Tutorial Notebook 6a</a>, to view the interactive HTML file, navigate to it via the directory listing in the left-hand side panel of this Jupyter notebook graphical interface, and click on its name.  This will open another tab in which one can view the HTML file.  Since it is relatively small (c. 3.6MB), the file should load quickly (within a few seconds).  Once loading is complete, click on the \"Trust HTML\" button at the top-left of the tab's window.  You should see an near-duplicate of the two linked plots that we produced just above."
+    "As in the <a href=\"./06a_Interactive_OImage_Visualization.ipynb\">Tutorial Notebook 6a</a>, to view the interactive HTML file, navigate to it via the directory listing in the left-hand side panel of this Jupyter notebook graphical interface, and click on its name.  This will open another tab in which one can view the HTML file.  Since it is relatively small (about 3.6 MB), the file should load quickly (within a few seconds).  Once loading is complete, click on the \"Trust HTML\" button at the top-left of the tab's window.  You should see an near-duplicate of the two linked plots that we produced just above.\n",
+    "\n",
+    "You can also download the file and interact with it by opening it in a browser on your local computer."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4.3. Linked streams\n",
+    "### 4.4. Linked streams\n",
     "\n",
-    "If we want to do subsequent calculations with the set of selected points, we can use HoloViews linked streams for custom interactivity. The following visualization is a modification of this example. As for the example above, use the selection box and selection lasso to choose datapoints on the left panel. The selected points should appear in the right panel. Finally, notice that as you change the selection on the left panel, the mean x- and y-values for selected datapoints are shown in the title of right panel.\n",
+    "If we want to do subsequent calculations with the set of selected points, we can use HoloViews linked streams for custom interactivity. The following visualization is a modification of this example. As for the example above, in the plots generated below use the selection box and selection lasso to choose datapoints on the left panel. The selected points should appear in the right panel. Finally, notice that as you change the selection on the left panel, the mean x- and y-values for selected datapoints are shown in the title of right panel.\n",
     "\n",
     "This section is based on [Holoviews Selection1D points](http://holoviews.org/reference/streams/bokeh/Selection1D_points.html)."
    ]
@@ -1031,7 +1037,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Define a function that uses the selection indices to slice points and compute statistics. This function is only used in the following cell, for the plot below."
+    "Define a function that uses the selection indices to slice points and compute statistics.\n",
+    "This function is defined here (and not in Section 1.2) because it is only used in the following cell, for the plot below."
    ]
   },
   {
@@ -1362,7 +1369,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create custom callback functionality to update the linked histogram"
+    "Create custom callback functionality to update the linked histogram.\n",
+    "\n",
+    "These functions are defined here (and not in Section 1.2) because they are only used in the following cell, for the plot below."
    ]
   },
   {


### PR DESCRIPTION
Added an example in each of NB06a and NB06b to output interactive HTML files from interactive images/plots in these notebooks.  Changes are primarily in Section 3.1 of NB06a and in Section 4 and 4.2 of NB06b.