### PR TITLE
PREOPS-3472b: Fix any issues with tutorial notebooks that arise before/during the Virtual Summer School

### DIFF
--- a/02_Catalog_Queries_with_TAP.ipynb
+++ b/02_Catalog_Queries_with_TAP.ipynb
@@ -597,6 +597,8 @@
     "\n",
     "Do not set a maximum number of records to return, because the goal is to generate a table containing the ForcedSource photometry for all of the Objects of interest. There is no need to use ORDER BY for this example, but it could be.\n",
     "\n",
+    "NOTE: When restricting a JOIN query to just a portion of the sky (e.g., a cone search), restricting on coordinates in `Object`, `DiaObject`, or `Source` where possible can result in significantly improved performance.\n",
+    "\n",
     "This query usually takes <2 minutes."
    ]
   },

--- a/02_Catalog_Queries_with_TAP.ipynb
+++ b/02_Catalog_Queries_with_TAP.ipynb
@@ -597,7 +597,7 @@
     "\n",
     "Do not set a maximum number of records to return, because the goal is to generate a table containing the ForcedSource photometry for all of the Objects of interest. There is no need to use ORDER BY for this example, but it could be.\n",
     "\n",
-    "NOTE: When restricting a JOIN query to just a portion of the sky (e.g., a cone search), restricting on coordinates in `Object`, `DiaObject`, or `Source` where possible can result in significantly improved performance.\n",
+    "> **Notice:** When restricting a JOIN query to just a portion of the sky (e.g., a cone search), restricting on coordinates in `Object`, `DiaObject`, or `Source` where possible can result in significantly improved performance.\n",
     "\n",
     "This query usually takes <2 minutes."
    ]

--- a/04b_Intermediate_Butler_Queries.ipynb
+++ b/04b_Intermediate_Butler_Queries.ipynb
@@ -509,12 +509,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.3. Retrieving data with butler.getDirect()\n",
+    "### 2.3. Retrieving data with a datasetRef passed to butler.get()\n",
     "\n",
     "One of the beauties of the Butler is that there is no need to know exactly where the data live in order to access it.\n",
     "In previous notebooks we've seen how to pass a dataId to Butler.get to return an instance of the appropriate object.\n",
-    "When you already have a datasetRef, it is faster and more efficient to use Butler.getDirect. \n",
-    "Here we use Butler.getDirect to retrieve the calexp and then get the detector Id from the calexp's properties."
+    "When you already have a datasetRef, it is faster and more efficient to pass the datasetRef to Butler.get. \n",
+    "Here we use Butler.get to retrieve the calexp and then get the detector Id from the calexp's properties."
    ]
   },
   {

--- a/07b_Variable_Star_Lightcurves.ipynb
+++ b/07b_Variable_Star_Lightcurves.ipynb
@@ -455,6 +455,7 @@
     "plt.minorticks_on()\n",
     "plt.xlabel('MJD (days)')\n",
     "plt.ylabel('r')\n",
+    "plt.gca().invert_yaxis()\n",
     "plt.show()"
    ]
   },

--- a/08_Truth_Tables.ipynb
+++ b/08_Truth_Tables.ipynb
@@ -442,6 +442,8 @@
     "\n",
     "The `MatchesTruth` table provides identifying information to pick out objects that have matches to truth objects. In order to compare _measured_ quantities (e.g., fluxes) from the `Object` table to the simulated truth values, we also need data from the `TruthSummary` table. This requires joining all three tables.\n",
     "\n",
+    "> **Notice:** When restricting a JOIN query to just a portion of the sky (e.g., a cone search), restricting on coordinates in `Object`, `DiaObject`, or `Source` where possible can result in significantly improved performance.\n",
+    "\n",
     "Note that the table length is now equal to the number of matched objects printed above (14850)."
    ]
   },

--- a/08_Truth_Tables.ipynb
+++ b/08_Truth_Tables.ipynb
@@ -459,7 +459,7 @@
     "        \"FROM dp02_dc2_catalogs.MatchesTruth AS mt \"\\\n",
     "        \"JOIN dp02_dc2_catalogs.TruthSummary AS ts ON mt.id_truth_type = ts.id_truth_type \"\\\n",
     "        \"JOIN dp02_dc2_catalogs.Object AS obj ON mt.match_objectId = obj.objectId \"\\\n",
-    "        \"WHERE CONTAINS(POINT('ICRS', ts.ra, ts.dec), CIRCLE('ICRS', 62.0, -37.0, 0.10)) = 1 \"\n",
+    "        \"WHERE CONTAINS(POINT('ICRS', obj.coord_ra, obj.coord_dec), CIRCLE('ICRS', 62.0, -37.0, 0.10)) = 1 \"\n",
     "results = service.search(query)\n",
     "results.to_table()"
    ]
@@ -572,7 +572,7 @@
     "        \"FROM dp02_dc2_catalogs.MatchesTruth AS mt \"\\\n",
     "        \"JOIN dp02_dc2_catalogs.TruthSummary AS ts ON mt.id_truth_type = ts.id_truth_type \"\\\n",
     "        \"JOIN dp02_dc2_catalogs.Object AS obj ON mt.match_objectId = obj.objectId \"\\\n",
-    "        \"WHERE CONTAINS(POINT('ICRS', ts.ra, ts.dec), CIRCLE('ICRS', 62.0, -37.0, 0.10)) = 1 \"\\\n",
+    "        \"WHERE CONTAINS(POINT('ICRS', obj.coord_ra, obj.coord_dec), CIRCLE('ICRS', 62.0, -37.0, 0.10)) = 1 \"\\\n",
     "        \"AND ts.truth_type = 1 \"\\\n",
     "        \"AND obj.detect_isPrimary = 1\"\n",
     "print(query)"


### PR DESCRIPTION
Summary of changes that were made (including the one on the previously-merged tickets/PREOPS-3472 branch):

NB02: Added the following tip to Sec. 3.3 per Fritz Meuller and Colin Slater's advice: "NOTE: When restricting a JOIN query to just a portion of the sky (e.g. a cone search), restricting on coordinates in Object, DiaObject, or Source where possible can result in significantly improved performance."

NB03a: Change a variable name so the result of calling the cutout_calexp function is not also called cutout_calexp (rename to my_cutout_calexp). (Already merged last week on tickets/PREOPS-3472 branch)

NB04b: Updated the description in Section 2.3 to correctly reference butler.get rather than the deprecated butler.getDirect().

NB07b: Inverted the y-axis in the first plot of mags vs. time (so that brighter is at the top).

NB08: Changed triple-table-join queries to use constraints on positions from Object instead of TruthSummary.