### PR TITLE
follow Lee Kelvin's advice about avoiding POSIX-style inspection and …

### DIFF
--- a/09_Custom_Coadds/09a_Custom_Coadd.ipynb
+++ b/09_Custom_Coadds/09a_Custom_Coadd.ipynb
@@ -830,7 +830,7 @@
     "> `setup lsst_distrib` <br>\n",
     "> `pipetask build -p $DRP_PIPE_DIR/pipelines/LSSTCam-imSim/DRP-test-med-1.yaml --show pipeline`<br>\n",
     "\n",
-    "You will see quite a lot of yaml output as a result of this command. For more information about `pipetask build`, please check out the  <a href=\"https://dp0-2.lsst.io/tutorials-examples/cmdline-custom-coadd.html\">command line version</a> of this custom coadd tutorial.\n",
+    "You will see quite a lot of yaml output as a result of this command. For more information about `pipetask build`, please check out the  <a href=\"https://dp0-2.lsst.io/tutorials-examples/cmdline-custom-coadd.html\">command line version</a> of this custom coadd tutorial. Note that, witihin the `pipetask build` yaml output, the ordering of tasks within a given step may be randomized.\n",
     "\n",
     "You can see an abbreviated version of the DP0 pipeline definition yaml by isolating \"step3\" as follows, where \"step3\" refers to coaddition:\n",
     "    \n",

--- a/09_Custom_Coadds/09a_Custom_Coadd.ipynb
+++ b/09_Custom_Coadds/09a_Custom_Coadd.ipynb
@@ -821,22 +821,23 @@
     "\n",
     "**The \"yaml\" file.**\n",
     "    \n",
-    "A yaml file is a human-readable data-serialization language.\n",
+    "yaml is a human-readable data-serialization language.\n",
     "It is commonly used for configuration files and in applications where data are being stored or transmitted. \n",
     "    \n",
-    "The other tasks available are listed in the yaml file. \n",
-    "To see the other tasks, first open a new terminal (click the blue + button at upper left and then select terminal).\n",
-    "Then create a Rubin Observatory environment, navigate to the yaml file used below, and view its contents with:\n",
+    "All the DP0 tasks are listed in the DPO data release production pipeline definition yaml.\n",
+    "To see this full list of tasks, first open a new terminal (click the blue + button at upper left and then select terminal).\n",
+    "Then create a Rubin Observatory environment, and render the pipeline yaml content via the `pipetask build` command:\n",
     "> `setup lsst_distrib` <br>\n",
-    "> `cd $DRP_PIPE_DIR/pipelines/LSSTCam-imSim`<br>\n",
-    "> `more DRP-test-med-1.yaml`\n",
+    "> `pipetask build -p $DRP_PIPE_DIR/pipelines/LSSTCam-imSim/DRP-test-med-1.yaml --show pipeline`<br>\n",
     "\n",
-    "You will see that this yaml file imports from other files, such as `$DRP_PIPE_DIR/ingredients/LSSTCam-imSim/DRP.yaml`.\n",
-    "Follow this redirect to view the imported yaml file contents.\n",
-    "We are using a yaml file with DP0-specific configurations. This is likely to change for future data previews.\n",
+    "You will see quite a lot of yaml output as a result of this command. For more information about `pipetask build`, please check out the  <a href=\"https://dp0-2.lsst.io/tutorials-examples/cmdline-custom-coadd.html\">command line version</a> of this custom coadd tutorial.\n",
     "\n",
-    "> `cd $DRP_PIPE_DIR/ingredients/LSSTCam-imSim`<br>\n",
-    "> `more DRP.yaml`"
+    "You can see an abbreviated version of the DP0 pipeline definition yaml by isolating \"step3\" as follows, where \"step3\" refers to coaddition:\n",
+    "    \n",
+    "> `pipetask build -p $DRP_PIPE_DIR/pipelines/LSSTCam-imSim/DRP-test-med-1.yaml#step3 --show pipeline`<br>\n",
+    "    \n",
+    "The above command assumes that you've already run `setup lsst_distrib` to set up the LSST software stack environment.\n",
+    "    "
    ]
   },
   {
@@ -848,7 +849,7 @@
     "\n",
     "To create a custom coadd, only two steps need to be rerun: `makeWarp` and `assembleCoadd`. \n",
     "\n",
-    "In the file `$DRP_PIPE_DIR/ingredients/LSSTCam-imSim/DRP.yaml`, you will find these defined as the first two sub-steps of \"step3\", and that they are usually followed by the sub-step `detection`. \n",
+    "In the file `$DRP_PIPE_DIR/pipelines/LSSTCam-imSim/DRP-test-med-1.yaml`, you will find these defined as the first two sub-steps of \"step3\", and that they are usually followed by the sub-step `detection`. \n",
     "\n",
     "However, we omit that sub-step and do source detection and measurement in the next tutorial notebook in this series, 09b_Custom_Coadd_Sources.ipynb."
    ]


### PR DESCRIPTION
…'ingredients'

Follows Lee's preferred path for addressing the issue raised in PREOPS-3504, namely to get rid of all mentions of "ingredients" and to avoid any usage of POSIX-style pipeline definition YAML inspection commands.