### PR TITLE
for QuantumGraph viz, use content from official DP0.2 website

### DIFF
--- a/DP02_09_Custom_Coadds/DP02_09b_Custom_Coadd_Sources.ipynb
+++ b/DP02_09_Custom_Coadds/DP02_09b_Custom_Coadd_Sources.ipynb
@@ -525,7 +525,7 @@
    "id": "9109506a-7d20-4f98-99db-0d8d66aa686e",
    "metadata": {},
    "source": [
-    "<img align=\"left\" src = https://raw.githubusercontent.com/rubin-dp0/cst-dev/main/AMM_detritus/9b_command_line/source_detection_qgraph.png width=\"100%\" style=\"padding: 10px\">"
+    "<img align=\"left\" src = https://dp0-2.lsst.io/_images/detectionMergeDetectionsDeblendMeasure-DRP.png width=\"100%\" style=\"padding: 10px\">"
    ]
   },
   {


### PR DESCRIPTION
single line change only

now that PREOPS-3435 has been merged into main in the dp0-2_lsst_io repo, it makes sense to link the source detection QuantumGraph in this notebook to that, rather than a raw.githubusercontent URL