### PR TITLE
[DM-17872] Fix column names

### DIFF
--- a/DP03_01_Introduction_to_DP03.ipynb
+++ b/DP03_01_Introduction_to_DP03.ipynb
@@ -372,8 +372,8 @@
    },
    "outputs": [],
    "source": [
-    "min_val = int(results[0].get('min'))\n",
-    "max_val = int(results[0].get('max'))\n",
+    "min_val = int(results[0].get('min1'))\n",
+    "max_val = int(results[0].get('max2'))\n",
     "print('Full range: ', min_val, max_val)\n",
     "\n",
     "min_val = int(max_val - 0.01*(max_val-min_val))\n",


### PR DESCRIPTION
The returned column names for functions and other things needed a number to get to be unique over the whole query.  For example, if you are doing two max()'s you need to be able to tell them apart.