### PR TITLE
Added updates per JIRA issue PREOPS-3791

### DIFF
--- a/DP02_11_User_Packages/DP02_11_Working_with_user_packages.ipynb
+++ b/DP02_11_User_Packages/DP02_11_Working_with_user_packages.ipynb
@@ -7,9 +7,9 @@
    "source": [
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<br><b>Working with user installed packages</b> <br>\n",
-    "Contact author: Leanne Guy <br>\n",
-    "Last verified to run: 2023-11-29<br>\n",
-    "LSST Science Piplines version: Weekly 2023_47<br>\n",
+    "Contact author(s): Leanne Guy, Douglas Tucker <br>\n",
+    "Last verified to run: 2024-02-27<br>\n",
+    "LSST Science Piplines version: Weekly 2024_04<br>\n",
     "Container size: medium <br>\n",
     "Targeted learning level: beginner <br>"
    ]
@@ -25,9 +25,9 @@
     "\n",
     "**LSST Data Products:** N/A\n",
     "\n",
-    "**Packages:** os, bagpipes, PyMultiNest, MultiNest, PyCuba, Cuba\n",
+    "**Packages:** os, bagpipes, PyMultiNest, MultiNest, PyCuba, Cuba, astroML\n",
     "\n",
-    "**Credit:** Created by Leanne Guy.\n",
+    "**Credit:** Created by Leanne Guy, with some additional material supplied by Douglas Tucker.\n",
     "\n",
     "**Get Support:**\n",
     "Find DP0-related documentation and resources at <a href=\"https://dp0-2.lsst.io\">dp0-2.lsst.io</a>. Questions are welcome as new topics in the <a href=\"https://community.lsst.org/c/support/dp0\">Support - Data Preview 0 Category</a> of the Rubin Community Forum. Rubin staff will respond to all questions posted there."
@@ -72,21 +72,25 @@
     "Before the bagpipes package can be used, the MultiNest package must be installed, \n",
     "and the environment of the LSST kernel updated.\n",
     "\n",
-    "It is recommended to install packages in a ```~/local``` directory.\n",
+    "Packages can be installed in a ```~/local``` directory, or in a preferred equivalent, \n",
+    "if the user has already installed other user packages into another directory in their  \n",
+    "user area on the RSP.  (For instance, other popular choices for a directory of\n",
+    "user-installed packages include ```~/.local``` or ```~/software```.)\n",
     "\n",
-    "First check if this directory exists by attempting to list it using the terminal command line.\n",
+    "Check if the ```~/local``` directory (or a preferred equivalent) already exists, \n",
+    "by attempting to list it using the terminal command line; _e.g._:\n",
     "\n",
     "```\n",
     "ls ~/local\n",
     "```\n",
     "\n",
-    "If the message \"cannot access\" is returned, create the directory using the terminal command line.\n",
+    "If the message \"cannot access\" is returned, create the directory using the terminal command line; _e.g._:\n",
     "\n",
     "```\n",
     "mkdir ~/local\n",
     "```\n",
     "\n",
-    "Then execute the following, one by one, from the terminal command line.\n",
+    "Once a ```~/local``` directory (or its equivalent) has been determined to exist, execute the following, one by one, from the terminal command line.\n",
     "\n",
     "```\n",
     "cd ~/local\n",
@@ -95,6 +99,17 @@
     "cmake ..\n",
     "make\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f9fbecb-237c-4982-a73d-2a57e12a476f",
+   "metadata": {},
+   "source": [
+    "_**Important: For the rest of this notebook, it will be assumed that the local package directory \n",
+    "is called ```~/local``` (or, equivalently, ```${HOME}/local```).  \n",
+    "If using a different name for the local package directory, please replace ```~/local``` \n",
+    "(```${HOME}/local```) in the following commands with the correct local package directory name.**_"
    ]
   },
   {
@@ -129,7 +144,9 @@
   {
    "cell_type": "markdown",
    "id": "ebc2e4fe-798a-46a9-9696-25b0393913bb",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true
+   },
    "source": [
     "### 1.3.2 Update the notebooks environment\n",
     "\n",
@@ -170,7 +187,7 @@
    "source": [
     "# 2. Check the environment in the notebook and use the bagpipes package\n",
     "\n",
-    "Execute the next cell to inspect the ```LD_LIBRARY_PATH```. Note that the last entry should be ```${HOME}/local/MultiNest/lib```"
+    "Execute the next cell to inspect the ```LD_LIBRARY_PATH```. Note that the last entry should be ```${HOME}/local/MultiNest/lib``` ."
    ]
   },
   {
@@ -184,6 +201,14 @@
    "source": [
     "import os\n",
     "print(os.getenv('LD_LIBRARY_PATH'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6556723b-5b36-45e9-88ad-7b43a67becda",
+   "metadata": {},
+   "source": [
+    "Finally, execute the following cell to ensure that the bagpipes package is indeed being imported."
    ]
   },
   {
@@ -209,12 +234,189 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "190f89ec-71a6-45c1-8d28-cb10e243bc64",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-26T21:09:36.952477Z",
+     "iopub.status.busy": "2024-02-26T21:09:36.951588Z",
+     "iopub.status.idle": "2024-02-26T21:09:36.956472Z",
+     "shell.execute_reply": "2024-02-26T21:09:36.955652Z",
+     "shell.execute_reply.started": "2024-02-26T21:09:36.952432Z"
+    }
+   },
+   "source": [
+    "# 3. (Additional:)  Update the PYTHONPATH if needed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbd09fad-36ee-465c-8b4b-16a5a39aaf69",
+   "metadata": {},
+   "source": [
+    "This step should not generally be necessary if installing a package via ```pip install --user <package name>``` or ```python setup.py install --home=<directory name>```, but there may be times a manual update of one's ```PYTHONPATH``` environment variable is necessary.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1970533-9332-4bbc-a50e-6125a46ab330",
+   "metadata": {},
+   "source": [
+    "One such case may be that the package's install script has an error.  Another case may be if the user is updating or developing a python module one's self."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06b37a8d-4c28-4f7b-905e-08e5ec0ec45a",
+   "metadata": {},
+   "source": [
+    "As a concrete example of the latter, assume one wants to download the most recent version of Jake Vanderplas's <a href=https://www.astroml.org/>astroML</a> astronomy machine learning and data mining package from <a href=https://github.com/astroML/astroML>its GitHub repository</a>, perhaps with the idea of modifying some of the source code for one's own uses or even for <a href=https://www.astroml.org/development/contribution.html>contributing to the astroML project</a>."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea7dc5a6-1a86-4ba1-a3ea-cdf8a38e1cb4",
+   "metadata": {},
+   "source": [
+    "First, in the RSP terminal window, download download astroML from <a href=https://github.com/astroML/astroML>its GitHub repository</a> into an appropriate directory by running the following commands in an RSP terminal window:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a554923b-ba26-4c54-98ba-95cf67aa5d78",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "cd ~/WORK/GitHub\n",
+    "git clone git@github.com:astroML/astroML.git\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69c02604-a4f1-42ad-8c24-694b82f9cc2e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-27T20:43:49.073361Z",
+     "iopub.status.busy": "2024-02-27T20:43:49.072533Z",
+     "iopub.status.idle": "2024-02-27T20:43:49.078185Z",
+     "shell.execute_reply": "2024-02-27T20:43:49.077471Z",
+     "shell.execute_reply.started": "2024-02-27T20:43:49.073329Z"
+    }
+   },
+   "source": [
+    "Next, within the RSP terminal window, change into the upper-level directory of the just downloaded astroML package and print its path:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02033054-19d9-45b0-bb9d-8b40f712a3b0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-27T20:44:53.387867Z",
+     "iopub.status.busy": "2024-02-27T20:44:53.387065Z",
+     "iopub.status.idle": "2024-02-27T20:44:53.392051Z",
+     "shell.execute_reply": "2024-02-27T20:44:53.391385Z",
+     "shell.execute_reply.started": "2024-02-27T20:44:53.387822Z"
+    }
+   },
+   "source": [
+    "```\n",
+    "cd astroML\n",
+    "pwd\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b044f96-6aa7-4b4c-a1f9-5dfa937e114c",
+   "metadata": {},
+   "source": [
+    "As in <a href=#1.3.2-Update-the-notebooks-environment>Section 1.3.2</a>, update your ```~/notebooks/.user_setups```, this time adding the following line to this file:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45002e7d-102e-4b10-bc31-932cf415a7bc",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "export PYTHONPATH=${HOME}/WORK/GitHub/astroML:${PYTHONPATH}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b11da28-fb6c-4876-bccc-5be8a7b1a6a8",
+   "metadata": {},
+   "source": [
+    "(of course, using the location of the upper-level directory of _your_ astroML GitHub download \n",
+    "if it differs from ```${HOME}/WORK/GitHub/astroML```)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d167aedb-240a-489d-a889-366980a30c84",
+   "metadata": {},
+   "source": [
+    "As in <a href=#1.3.1-Update-the-terminal-environment>Section 1.3.1</a>, you can optionally add the export PYTHONPATH statement to the ~/.bashrc file so that this is setup automatically at the time of every login. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e052f4d7-2e73-4094-a1e7-9f20c84d4cf9",
+   "metadata": {},
+   "source": [
+    "Now, as in <a href=#1.4-Activate-the-new-setup>Section 1.4</a>, log out of the Notebook Aspect and log back in to activate the new PYTHONPATH."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53fae117-faba-4753-a1d5-1a3d4829913a",
+   "metadata": {},
+   "source": [
+    "Next, as in <a href=#2.-Check-the-environment-in-the-notebook-and-use-the-bagpipes-package>Section 2</a>, \n",
+    "execute the next cell to inspect the PYTHONPATH. Note that the *first* entry should be the location of your\n",
+    "downloaded astroML directory."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33d9c2a9-452e-4a06-923b-9ec60eba30cd",
+   "id": "7286fc3b-0271-4f9a-99bd-7471eac6da1f",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import os\n",
+    "print(os.getenv('PYTHONPATH'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c5fe017-41f9-4db2-b11d-fe0576dc2923",
+   "metadata": {},
+   "source": [
+    "Finally, as in <a href=#2.-Check-the-environment-in-the-notebook-and-use-the-bagpipes-package>Section 2</a>, \n",
+    "execute the following cell to ensure that your download of the astroML package is indeed being imported."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8adff26-9dc4-4042-8b50-37e380be8a63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astroML"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f35d29e2-e551-48f5-b03a-cc4909e1a80f",
+   "metadata": {},
+   "source": [
+    "No errors should be produced."
+   ]
   }
  ],
  "metadata": {
@@ -233,7 +435,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
 Variations of both proposed updates from [PREOPS-3791 ](https://jira.lsstcorp.org/browse/PREOPS-3791)have been implemented:

**Proposed Update 1**

Update: "Packages can be installed in a ~/local directory. (If you do not already have a ~/local directory, you can create one via the command mkdir ~/local)."
 
To say something like: "Packages can be installed in a ~/local directory (or your preferred equivalent, if you have already installed other user packages into another directory in your user area on the RSP). If you do not already have a ~/local directory (or your preferred equivalent), you can create one via the command mkdir ~/local)."

**Proposed Update 2**

Add a section describing how to add a path to one's PATH and PYTHONPATH environmental variables if, for some reason, a package's commands are not being "picked up" either on the command line or in a notebook. This should be taken care of automatically by "pip install --user <package name>" or "python setup.py install --home=<directory name>" in most cases.

For example, sometimes when downloading packages from GitHub, a full official install is not necessary and commands like this in the equivalent of the .bashrc, and/or ~/notebooks/.user_setups file, work fine:

```
# Setup DECam_PGCM environment...
export DECAM_PGCM_DIR=/usrdevel/dp0/dtucker/GitHub/DECam_PGCM
export PATH=${DECAM_PGCM_DIR}/bin:${PATH}
export PYTHONPATH=${DECAM_PGCM_DIR}/python:${PYTHONPATH}
```


---------------------

I followed pretty closely to the text of the original Proposed 1.

For Proposed Update 2, I used for a concrete example the case where the user downloads a bleeding edge of Jake Vanderplas's astroML package from github.com as a working copy -- possibly with the idea of modifying some of the downloaded astroML code -- and so does not wish to immediately install it in a regular installation directory.