### PR TITLE
add sky_object to query

### DIFF
--- a/DP02_12b_PSF_Science_Demo.ipynb
+++ b/DP02_12b_PSF_Science_Demo.ipynb
@@ -8,7 +8,7 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<b>Point Spread Function (PSF) Analysis for Cosmology </b> <br>\n",
     "Contact author(s): Andrés A. Plazas Malagón<br>\n",
-    "Last verified to run:  2024-01-31 <br>\n",
+    "Last verified to run:  2024-02-28 <br>\n",
     "LSST Science Pipelines version: Weekly 2024_04  <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: advanced <br>"
@@ -412,7 +412,7 @@
     "                         \"g_ixx, g_iyy, g_ixxPSF, g_iyyPSF, \"\n",
     "                         \"r_ixx, r_iyy, r_ixxPSF, r_iyyPSF, \"\n",
     "                         \"i_ixx, i_iyy, i_ixxPSF, i_iyyPSF, \"\n",
-    "                         \"xy_flag, \"\n",
+    "                         \"xy_flag, sky_object, \"\n",
     "                         \"detect_isPatchInner, \"\n",
     "                         \"detect_isDeblendedSource \"\n",
     "                         \"FROM dp02_dc2_catalogs.Object \"\n",


### PR DESCRIPTION
Add sky_object to the query on the object table. This avoids an error with analysis_tools with weekly 2024_08, for which the RhoStatistics input schema expects sky_object. Retrieving sky_object still works fine with the current recommended, 2024_04. Although it is not best practice to retrieve data that is unused, this fix stops CI from failing on the NB.