### PR TITLE
Updated polygon definition with factor for cosine declination

### DIFF
--- a/DP02_13a_Image_Cutout_SciDemo.ipynb
+++ b/DP02_13a_Image_Cutout_SciDemo.ipynb
@@ -8,7 +8,7 @@
     "### <img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\"> \n",
     "<b>Using the image cutout tool with DP0.2</b> <br>\n",
     "Contact author(s): Christina Williams <br>\n",
-    "Last verified to run: 2024-3-27 <br>\n",
+    "Last verified to run: 2024-4-25 <br>\n",
     "LSST Science Piplines version: Weekly <i>2024_4</i> <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: beginner <br>"
@@ -129,7 +129,7 @@
     "\n",
     "# Astropy\n",
     "from astropy import units as u\n",
-    "from astropy.coordinates import SkyCoord\n",
+    "from astropy.coordinates import SkyCoord, Angle\n",
     "from astropy.io import fits\n",
     "from astropy.wcs import WCS\n",
     "\n",
@@ -647,7 +647,7 @@
     "             sphereRadius)\n",
     "\n",
     "# first write the file to disk:\n",
-    "sodaCutout = os.path.join(os.getenv('HOME'), 'temp/soda-cutout.fits')\n",
+    "sodaCutout = os.path.join(os.getenv('HOME'), 'temp/soda-cutout-circle.fits')\n",
     "with open(sodaCutout, 'bw') as f:\n",
     "    f.write(sq.execute_stream().read())\n",
     "\n",
@@ -693,12 +693,46 @@
     "#               spherePoint.getRa().asDegrees()* u.deg + sphereRadius2,\n",
     "#               spherePoint.getDec().asDegrees()*u.deg - sphereRadius2)\n",
     "\n",
-    "sodaCutout2 = os.path.join(os.getenv('HOME'), 'temp/soda-cutout.fits')\n",
+    "sodaCutout2 = os.path.join(os.getenv('HOME'), 'temp/soda-cutout-polygon.fits')\n",
     "with open(sodaCutout2, 'bw') as f:\n",
     "    f.write(sq2.execute_stream().read())\n",
     "\n",
     "plotImage(ExposureF(sodaCutout2))\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6970143e-90b9-406c-80ce-e6c6ba923c1e",
+   "metadata": {},
+   "source": [
+    "There is an important difference to note between the circle and polygon shape definitions. The angular distance on the sky that defines the circular cutout size already accounts for the difference in angular distance in the RA direction is smaller by a factor of cos(declination), where declination is in units radians. The difference increases with higher declination. However, the polygon definition does not automatically account for this cosine factor. Thus, circle and polygon cutout definitions using the same cutout edge length will not match size in the RA direction (for deepCoadds, the x-axis). The cell below demonstrates how to make this correction to the polygon cutout definition to create symmetric cutouts with polygon. Here sphereRadius comes from the circle definition above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3407da92-6494-4ef0-9343-e5f4db20a87d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = Angle(spherePoint.getDec().asDegrees(), u.deg)\n",
+    "cosd = np.cos(a.radian)\n",
+    "\n",
+    "sq2.polygon = (spherePoint.getRa().asDegrees() * u.deg - sphereRadius/cosd,\n",
+    "               spherePoint.getDec().asDegrees() * u.deg - sphereRadius,\n",
+    "               spherePoint.getRa().asDegrees() * u.deg - sphereRadius/cosd,\n",
+    "               spherePoint.getDec().asDegrees() * u.deg + sphereRadius,\n",
+    "               spherePoint.getRa().asDegrees() * u.deg + sphereRadius/cosd,\n",
+    "               spherePoint.getDec().asDegrees() * u.deg + sphereRadius,\n",
+    "               spherePoint.getRa().asDegrees() * u.deg + sphereRadius/cosd,\n",
+    "               spherePoint.getDec().asDegrees() * u.deg - sphereRadius)\n",
+    "\n",
+    "sodaCutout2 = os.path.join(os.getenv('HOME'), 'temp/soda-cutout_polygon.fits')\n",
+    "with open(sodaCutout2, 'bw') as f:\n",
+    "    f.write(sq2.execute_stream().read())\n",
+    "\n",
+    "plotImage(ExposureF(sodaCutout2))\n"
    ]
   },
   {


### PR DESCRIPTION
Added explanation that polygon geometry definition for the cutout tool does not factor in the difference in angular distance in the RA direction that is smaller by a factor of cos(declination) than in the declination direction, and demonstration of the correction. 