### PR TITLE
tickets/PREOPS-5184: add rotated stamp injection to DP0.2 NB 14

### DIFF
--- a/DP02_14_Injecting_Synthetic_Sources.ipynb
+++ b/DP02_14_Injecting_Synthetic_Sources.ipynb
@@ -12,7 +12,7 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\" alt=\"Rubin Observatory logo, a graphical representation of turning stars into data.\">\n",
     "<br>\n",
     "Contact author: Jeff Carlin <br>\n",
-    "Last verified to run: 2024-06-10 <br>\n",
+    "Last verified to run: 2024-06-12 <br>\n",
     "LSST Science Pipelines version: Weekly 2024_16 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: advanced <br>"
@@ -135,8 +135,26 @@
     "import lsst.geom as geom\n",
     "from lsst.source.injection import ingest_injection_catalog, generate_injection_catalog\n",
     "from lsst.source.injection import VisitInjectConfig, VisitInjectTask\n",
-    "from lsst.ip.diffim.subtractImages import AlardLuptonSubtractTask, AlardLuptonSubtractConfig\n",
+    "from lsst.ip.diffim.subtractImages import AlardLuptonSubtractTask, AlardLuptonSubtractConfig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "662aa3ce-e9e5-4703-b3e3-15f554c7c325",
+   "metadata": {},
+   "source": [
+    "### 1.2 Define functions and parameters\n",
     "\n",
+    "Set `afwDisplay` to use `matplotlib`, and use colorblind-friendly colors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e75e7d7-4af9-4e2f-b25f-08b84d01823a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "afwDisplay.setDefaultBackend('matplotlib')\n",
     "plt.style.use('tableau-colorblind10')"
    ]
@@ -231,15 +249,27 @@
     "tract = 3828\n",
     "where = f\"instrument='LSSTCam-imSim' AND skymap='DC2' AND \\\n",
     "          tract={tract} AND detector=19 AND band='g'\"\n",
-    "\n",
     "calexp_g_DatasetRefs = sorted(list(set(butler.registry.queryDatasets('calexp', where=where))))\n",
-    "\n",
-    "print(f'Identified {len(calexp_g_DatasetRefs)} calexp DatasetRefs')\n",
-    "\n",
-    "# This uses the index \"5\" to select an arbitrary dataId.\n",
-    "# Change this index to select a different image.\n",
+    "print(f'Identified {len(calexp_g_DatasetRefs)} calexp DatasetRefs')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "217d700a-de66-488b-bdd6-ae90728993fb",
+   "metadata": {},
+   "source": [
+    "Use index \"5\" to select an arbitrary `dataId`.\n",
+    "Change this index to another integer to select a different image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12a63560-6f9c-4c21-954e-2163b8a6be43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dataId_g = calexp_g_DatasetRefs[5].dataId\n",
-    "\n",
     "print(f\"{dataId_g = }\")"
    ]
   },
@@ -268,7 +298,9 @@
    "source": [
     "#### 2.2.2 Retrieve additional information about the image\n",
     "\n",
-    "To generate synthetic sources to be injected into the image, you will need to know the coordinates of its bounding box. Retrieve the image's WCS and bounding box, and print its central coordinate to the screen:"
+    "To generate synthetic sources to be injected into the image, the coordinates of its bounding box are necessary.\n",
+    "\n",
+    "Retrieve the image's WCS and bounding box, and print its central coordinate to the screen:"
    ]
   },
   {
@@ -296,7 +328,9 @@
    "source": [
     "#### 2.2.3 Figure out how large the image is on the sky\n",
     "\n",
-    "Note that above the bounding box is roughly 4000 x 4000 pixels. Use the `bbox.getDimensions` and `wcs.getPixelScale` methods to estimate how large this image is in sky coordinates:"
+    "Note that above the bounding box is roughly 4000 x 4000 pixels.\n",
+    "\n",
+    "Use the `bbox.getDimensions` and `wcs.getPixelScale` methods to estimate how large this image is in sky coordinates."
    ]
   },
   {
@@ -333,7 +367,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inject_size = 0.2/2  # in degrees"
+    "inject_size = 0.2/2"
    ]
   },
   {
@@ -475,7 +509,7 @@
    "source": [
     "#### 3.2.1 Create an entry in the injection catalog for the postage stamp image\n",
     "\n",
-    "Add a postage stamp entry into the injection catalog, using `vstack` to add an astropy `Table` containing a single row. You must specify its position, magnitude, and \"source_type = Stamp,\" in addition to the filename of the image to inject. (It is OK to leave unnecessary columns empty.)"
+    "Add a postage stamp entry into the injection catalog, using `vstack` to add an astropy `Table` containing a single row. Specify its position, magnitude, and \"source_type = Stamp,\" in addition to the filename of the image to inject. (It is OK to leave unnecessary columns empty.)"
    ]
   },
   {
@@ -524,9 +558,11 @@
    "source": [
     "#### 3.2.2 Create a rotated version of the stamp image, and add an entry for it into the injection catalog\n",
     "\n",
-    "If you would like to apply a rotation to the postage stamp image before injecting it into the `calexp`, the \"rotateExposure\" function created above will do that for you. Here we will read the image, apply a rotation to it, then write it out as a new image. Then we will follow the same steps as the previous section to add it to the injection catalog.\n",
+    "To apply a rotation to the postage stamp image before injecting it into the `calexp`, use the `rotateExposure` function created above.\n",
     "\n",
-    "First, read the postage stamp image using the `afwImage` package (it's OK to ignore the warning that will pop up):"
+    "The process is to read the image, apply a rotation to it, write it out as a new image, and then follow the same steps as the previous section to add it to the injection catalog.\n",
+    "\n",
+    "First, read the postage stamp image using the `afwImage` package. It's OK to ignore the warning about an expected extension type that will pop up."
    ]
   },
   {
@@ -616,7 +652,7 @@
    "id": "f3e476fa-b40e-4d3b-a9c8-f0d0a05f99c1",
    "metadata": {},
    "source": [
-    "Write the rotated stamp to an output file in your home directory:"
+    "Write the rotated stamp to an output file in the home directory."
    ]
   },
   {
@@ -635,7 +671,7 @@
    "id": "b5987196-89b5-4b10-91c4-445b86c4275f",
    "metadata": {},
    "source": [
-    "Add an entry to the injection catalog for the rotated stamp:"
+    "Add an entry to the injection catalog for the rotated stamp."
    ]
   },
   {
@@ -683,13 +719,52 @@
     "### 3.3 Ingest the synthetic source catalog into a butler collection\n",
     "\n",
     "#### 3.3.1 Register the source injection collection\n",
-    "The input `inject_cat` will be ingested into a collection called `u/{user}/test_injection_inputs` (where \"user\" will be your username) in the butler repository. You must register this collection for subsequent use.\n",
     "\n",
-    "First, instantiate a writeable `butler`. Butlers are instantiated in read-only mode by default. By setting the argument `writeable` to `True`, a butler can also be made to be writeable.\n",
+    "The input `inject_cat` will be ingested into a collection called `u/{user}/test_injection_inputs` (where \"user\" will be the account username) in the butler repository. \n",
     "\n",
-    "> Warning: take care when working with a writeable butler, as data on-disk has the potential to be permanently removed or corrupted.\n",
+    "This demonstrates an alternate way to obtain a username (compared to the use of `getpass` demonstrated above)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5aa99d39-9f1f-4a98-af42-05d1010e5e8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user = os.getenv(\"USER\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a0a1036-312a-479b-b15b-908a7643eab0",
+   "metadata": {},
+   "source": [
+    "Define the name of the collection.\n",
     "\n",
-    "_Note: If you attempt to inject synthetic sources into a collection that already exists, the task will complain that the output data already exist on disk. The name you assign to your collection in `INJECTION_CATALOG_COLLECTION` in the following cell must not have been used before. (This means that if you have run source injection already, you must change the output collection name before running again.)_"
+    "> Notice: If an attempt is made to inject synthetic sources into a collection that already exists, the task will complain that the output data already exist on disk. The name assigned to the collection in `INJECTION_CATALOG_COLLECTION` in the following cell must not have been used before. If it has been, choose a new name (or add a unique string, such as a timestamp like `_20240610_1600`, to the end of it) for each rerun."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "037b2281-dd1e-4c4d-a4de-0213c9bb9a92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "INJECTION_CATALOG_COLLECTION = f\"u/{user}/test_injection_inputs_2\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1cb5c620-44da-4c72-be7a-cb1cf0e45b4d",
+   "metadata": {},
+   "source": [
+    "The collection must be registered in order to use it.\n",
+    "\n",
+    "Instantiate a writeable `butler`. Butlers are instantiated in read-only mode by default. By setting the argument `writeable` to `True`, a butler can also be made to be writeable.\n",
+    "\n",
+    "> Warning: take care when working with a writeable butler, as data on-disk has the potential to be permanently removed or corrupted."
    ]
   },
   {
@@ -699,12 +774,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get username.\n",
-    "user = os.getenv(\"USER\")\n",
-    "\n",
-    "INJECTION_CATALOG_COLLECTION = f\"u/{user}/test_injection_inputs\"\n",
-    "\n",
-    "# Instantiate a writeable butler.\n",
     "writeable_butler = Butler(butler_config, writeable=True)"
    ]
   },
@@ -778,7 +847,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load input injection catalogs.\n",
     "injection_refs = butler.registry.queryDatasets(\n",
     "    \"injection_catalog\",\n",
     "    band=\"g\",\n",
@@ -949,7 +1017,7 @@
     "\n",
     "The first two lines below load the default configuration for the `AlardLuptonSubtract` task, and then initialize the task with that configuration. The task requires (1) a template exposure, (2) the science exposure, and (3) the catalog of sources from the science exposure.\n",
     "\n",
-    "Load the source catalog (`src`) and run the task:"
+    "Load the source catalog (`src`) and run the task."
    ]
   },
   {
@@ -975,7 +1043,10 @@
    "source": [
     "#### 4.4.3 Compare the original and the difference image\n",
     "\n",
-    "Plot the original `calexp`, the injected image, and the difference image side by side:"
+    "Plot the original `calexp`, the injected image, and the difference image side by side.\n",
+    "\n",
+    "Set `xmin`, `xmax`, `ymin`, and `ymax` to zoom in on an arbitrary section of the image.\n",
+    "Change the values to zoom in on a different region."
    ]
   },
   {
@@ -985,8 +1056,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Zoom in on an arbitrary section of the image.\n",
-    "# Change these coordinates to see a different region.\n",
     "xmin, xmax = 500, 2000\n",
     "ymin, ymax = 1000, 2500\n",
     "\n",

--- a/DP02_14_Injecting_Synthetic_Sources.ipynb
+++ b/DP02_14_Injecting_Synthetic_Sources.ipynb
@@ -124,6 +124,7 @@
     "import astropy.units as u\n",
     "from astropy.table import Table, vstack\n",
     "from astropy.coordinates import SkyCoord\n",
+    "import getpass\n",
     "\n",
     "import lsst.afw.display as afwDisplay\n",
     "import lsst.afw.geom as afwGeom\n",
@@ -491,8 +492,7 @@
     "        'dec': [-36.488],\n",
     "        'source_type': ['Stamp'],\n",
     "        'mag': [14.8],\n",
-    "        'stamp': ['PGC_038749_I_g_bbl2011.fits'],\n",
-    "        'stamp_prefix': ['data/'],\n",
+    "        'stamp': ['data/PGC_038749_I_g_bbl2011.fits'],\n",
     "    }\n",
     ")"
    ]
@@ -525,8 +525,6 @@
     "#### 3.2.2 Create a rotated version of the stamp image, and add an entry for it into the injection catalog\n",
     "\n",
     "If you would like to apply a rotation to the postage stamp image before injecting it into the `calexp`, the \"rotateExposure\" function created above will do that for you. Here we will read the image, apply a rotation to it, then write it out as a new image. Then we will follow the same steps as the previous section to add it to the injection catalog.\n",
-    "\n",
-    "_Note: This subsection will not work if you are executing the notebook in the read-only \"~/notebooks/tutorial_notebooks\" directory. To run it, you will need to copy the notebook to a different directory so that you can save the modified image. (You could also just skip Sec. 3.2.2, and everything will run fine.)_\n",
     "\n",
     "First, read the postage stamp image using the `afwImage` package (it's OK to ignore the warning that will pop up):"
    ]
@@ -618,7 +616,7 @@
    "id": "f3e476fa-b40e-4d3b-a9c8-f0d0a05f99c1",
    "metadata": {},
    "source": [
-    "Write the rotated stamp to an output file in the \"data/\" directory:"
+    "Write the rotated stamp to an output file in your home directory:"
    ]
   },
   {
@@ -628,7 +626,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stamp_img_rotated.writeFits('data/stamp_rotated.fits')"
+    "home_directory = '/home/' + getpass.getuser() + '/'\n",
+    "stamp_img_rotated.writeFits(home_directory+'stamp_rotated.fits')"
    ]
   },
   {
@@ -653,8 +652,7 @@
     "        'dec': [-36.488],\n",
     "        'source_type': ['Stamp'],\n",
     "        'mag': [14.8],\n",
-    "        'stamp': ['stamp_rotated.fits'],\n",
-    "        'stamp_prefix': ['data/'],\n",
+    "        'stamp': [home_directory+'stamp_rotated.fits'],\n",
     "    }\n",
     ")"
    ]
@@ -667,16 +665,6 @@
    "outputs": [],
    "source": [
     "inject_cat = vstack([inject_cat, my_injection_catalog_rotated_stamp])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "720d83e7-96a8-4711-889d-d440ac3346af",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "inject_cat"
    ]
   },
   {
@@ -714,7 +702,7 @@
     "# Get username.\n",
     "user = os.getenv(\"USER\")\n",
     "\n",
-    "INJECTION_CATALOG_COLLECTION = f\"u/{user}/test_injection_inputs_10jun2024\"\n",
+    "INJECTION_CATALOG_COLLECTION = f\"u/{user}/test_injection_inputs\"\n",
     "\n",
     "# Instantiate a writeable butler.\n",
     "writeable_butler = Butler(butler_config, writeable=True)"
@@ -808,7 +796,7 @@
    "source": [
     "### 4.2 Instantiate the injection classes\n",
     "\n",
-    "First, instantiate the `VisitInjectConfig` class. The `VisitInjectConfig` class is where configuration of the injection task occurs, allowing for modifications to be made to how the task operates. Here, change the \"stamp_prefix\" configuration option to \"data/\" so that `source_injection` knows to look for the image in the `data/` folder.\n",
+    "First, instantiate the `VisitInjectConfig` class. The `VisitInjectConfig` class is where configuration of the injection task occurs, allowing for modifications to be made to how the task operates.\n",
     "\n",
     "Then instantiate the `VisitInjectTask`, using `inject_config` as the configuration argument.\n",
     "\n",
@@ -829,7 +817,6 @@
    "outputs": [],
    "source": [
     "inject_config = VisitInjectConfig()\n",
-    "inject_config.stamp_prefix = 'data/'\n",
     "\n",
     "inject_task = VisitInjectTask(config=inject_config)"
    ]
@@ -1034,7 +1021,7 @@
    "id": "3d5af646-bb96-48c1-9343-8979f93fa40d",
    "metadata": {},
    "source": [
-    "# 6. Exercises for the learner\n",
+    "# 5. Exercises for the learner\n",
     "\n",
     "Further explorations could include:\n",
     "\n",
@@ -1043,6 +1030,14 @@
     "3.  Injecting variable objects into multiple calexp images and testing their recoverability.\n",
     "4.  Running detection and measurement tasks from the LSST Science Pipelines to test the recovery and measurement accuracy of injected sources (e.g., following DP0.2 tutorial [Notebook 05: Introduction to Source Detection](https://github.com/rubin-dp0/tutorial-notebooks/blob/main/DP02_05_Introduction_to_Source_Detection.ipynb))."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "098ae337-1e58-409c-88ba-114ca4ba3a1b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/DP02_14_Injecting_Synthetic_Sources.ipynb
+++ b/DP02_14_Injecting_Synthetic_Sources.ipynb
@@ -12,7 +12,7 @@
     "<img align=\"left\" src = https://project.lsst.org/sites/default/files/Rubin-O-Logo_0.png width=250 style=\"padding: 10px\" alt=\"Rubin Observatory logo, a graphical representation of turning stars into data.\">\n",
     "<br>\n",
     "Contact author: Jeff Carlin <br>\n",
-    "Last verified to run: 2024-05-01 <br>\n",
+    "Last verified to run: 2024-06-10 <br>\n",
     "LSST Science Pipelines version: Weekly 2024_16 <br>\n",
     "Container Size: medium <br>\n",
     "Targeted learning level: advanced <br>"
@@ -125,17 +125,63 @@
     "from astropy.table import Table, vstack\n",
     "from astropy.coordinates import SkyCoord\n",
     "\n",
-    "from lsst.afw.table import SourceTable\n",
-    "from lsst.daf.base import PropertyList\n",
+    "import lsst.afw.display as afwDisplay\n",
+    "import lsst.afw.geom as afwGeom\n",
+    "import lsst.afw.image as afwImage\n",
+    "import lsst.afw.math as afwMath\n",
     "from lsst.daf.butler import Butler\n",
     "from lsst.daf.butler.registry import ConflictingDefinitionError\n",
-    "import lsst.afw.display as afwDisplay\n",
+    "import lsst.geom as geom\n",
     "from lsst.source.injection import ingest_injection_catalog, generate_injection_catalog\n",
     "from lsst.source.injection import VisitInjectConfig, VisitInjectTask\n",
     "from lsst.ip.diffim.subtractImages import AlardLuptonSubtractTask, AlardLuptonSubtractConfig\n",
     "\n",
     "afwDisplay.setDefaultBackend('matplotlib')\n",
     "plt.style.use('tableau-colorblind10')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1963fee-45c7-4689-852c-702f058af326",
+   "metadata": {},
+   "source": [
+    "The following function is a modified version of [this code](https://github.com/lsst/atmospec/blob/1e7d6e8e5655cc13d71b21ba866001e6d49ee04e/python/lsst/atmospec/utils.py#L259-L301)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3885e7c5-7a1f-485e-bdcb-ed6be31aa44f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rotate_exposure(exp, n_degrees):\n",
+    "    \"\"\"Rotate an exposure by nDegrees clockwise.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    exp : `lsst.afw.image.exposure.Exposure`\n",
+    "        The exposure to rotate\n",
+    "    n_degrees : `float`\n",
+    "        Number of degrees clockwise to rotate by\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    rotated_exp : `lsst.afw.image.exposure.Exposure`\n",
+    "        A copy of the input exposure, rotated by nDegrees\n",
+    "    \"\"\"\n",
+    "    n_degrees = n_degrees % 360\n",
+    "\n",
+    "    wcs = exp.getWcs()\n",
+    "\n",
+    "    warper = afwMath.Warper('lanczos4')\n",
+    "\n",
+    "    affine_rot_transform = geom.AffineTransform.makeRotation(n_degrees*geom.degrees)\n",
+    "    transform_p2top2 = afwGeom.makeTransform(affine_rot_transform)\n",
+    "    rotated_wcs = afwGeom.makeModifiedWcs(transform_p2top2, wcs, False)\n",
+    "\n",
+    "    rotated_exp = warper.warpExposure(rotated_wcs, exp)\n",
+    "    return rotated_exp"
    ]
   },
   {
@@ -473,6 +519,168 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ca79ab5c-b8c1-4768-bbbe-cab766300df9",
+   "metadata": {},
+   "source": [
+    "#### 3.2.2 Create a rotated version of the stamp image, and add an entry for it into the injection catalog\n",
+    "\n",
+    "If you would like to apply a rotation to the postage stamp image before injecting it into the `calexp`, the \"rotateExposure\" function created above will do that for you. Here we will read the image, apply a rotation to it, then write it out as a new image. Then we will follow the same steps as the previous section to add it to the injection catalog.\n",
+    "\n",
+    "_Note: This subsection will not work if you are executing the notebook in the read-only \"~/notebooks/tutorial_notebooks\" directory. To run it, you will need to copy the notebook to a different directory so that you can save the modified image. (You could also just skip Sec. 3.2.2, and everything will run fine.)_\n",
+    "\n",
+    "First, read the postage stamp image using the `afwImage` package (it's OK to ignore the warning that will pop up):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10d00f8c-ab25-4478-9f00-d23c454d2f11",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "stamp_img_orig = afwImage.ExposureF.readFits('data/PGC_038749_I_g_bbl2011.fits')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51ae9220-d6e4-466b-9ef1-e1b1115a9f66",
+   "metadata": {},
+   "source": [
+    "Apply a rotation to the image using the `rotateExposure` function defined above. This will apply a rotation to the WCS, and then \"warp\" the image (i.e., resample it) onto the new, rotated WCS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0fa1c3e-af7c-422d-9a94-20934fceb6e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rotation_angle = 57.0\n",
+    "stamp_img_rotated = rotate_exposure(stamp_img_orig, rotation_angle)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2369cc9-dcbd-4012-bc43-d85dd8fc9f70",
+   "metadata": {},
+   "source": [
+    "Confirm that the image has been rotated by displaying them side-by-side:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71ef330e-853d-42c8-b15e-84b0d0343f32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1, 2, figsize=(6, 4), dpi=150)\n",
+    "\n",
+    "plt.sca(ax[0])\n",
+    "display0 = afwDisplay.Display(frame=fig)\n",
+    "display0.scale('linear', min=-20, max=150)\n",
+    "display0.mtv(stamp_img_orig.image)\n",
+    "plt.title('original stamp image')\n",
+    "\n",
+    "plt.sca(ax[1])\n",
+    "display1 = afwDisplay.Display(frame=fig)\n",
+    "display1.scale('linear', min=-20, max=150)\n",
+    "display1.mtv(stamp_img_rotated.image)\n",
+    "plt.title('rotated stamp image')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a18309c-5ab6-4d22-a40f-60c87f801f0b",
+   "metadata": {},
+   "source": [
+    "When the image is rotated, the \"empty\" pixels are given NaN values. Replace those with zeros (if you leave them as NaNs, the image values will not be read correctly when reading in the resulting image)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a84caa50-f84f-4013-92a3-5d32e1a0b7d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stamp_img_rotated.image.array[np.where(np.isnan(stamp_img_rotated.image.array))] = 0.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3e476fa-b40e-4d3b-a9c8-f0d0a05f99c1",
+   "metadata": {},
+   "source": [
+    "Write the rotated stamp to an output file in the \"data/\" directory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64f29cde-d9cc-42a5-9581-695225000097",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stamp_img_rotated.writeFits('data/stamp_rotated.fits')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5987196-89b5-4b10-91c4-445b86c4275f",
+   "metadata": {},
+   "source": [
+    "Add an entry to the injection catalog for the rotated stamp:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f693331-af36-4d18-b280-b8b39eccc970",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_injection_catalog_rotated_stamp = Table(\n",
+    "    {\n",
+    "        'injection_id': [99999],\n",
+    "        'ra': [56.642],\n",
+    "        'dec': [-36.488],\n",
+    "        'source_type': ['Stamp'],\n",
+    "        'mag': [14.8],\n",
+    "        'stamp': ['stamp_rotated.fits'],\n",
+    "        'stamp_prefix': ['data/'],\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6311ed07-9674-43e3-a2cf-d33f3630f09d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inject_cat = vstack([inject_cat, my_injection_catalog_rotated_stamp])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "720d83e7-96a8-4711-889d-d440ac3346af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inject_cat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0d9960aa-0c91-4752-a5d9-a58b51c16a82",
    "metadata": {
     "execution": {
@@ -506,7 +714,7 @@
     "# Get username.\n",
     "user = os.getenv(\"USER\")\n",
     "\n",
-    "INJECTION_CATALOG_COLLECTION = f\"u/{user}/test_injection_inputs\"\n",
+    "INJECTION_CATALOG_COLLECTION = f\"u/{user}/test_injection_inputs_10jun2024\"\n",
     "\n",
     "# Instantiate a writeable butler.\n",
     "writeable_butler = Butler(butler_config, writeable=True)"
@@ -536,8 +744,8 @@
     "    )\n",
     "except ConflictingDefinitionError:\n",
     "    print(f\"Found an existing collection named INJECTION_CATALOG_COLLECTION={INJECTION_CATALOG_COLLECTION}.\")\n",
-    "    print(\"\\nNOTE THAT IF YOU SEE THIS MESSAGE, YOUR CATALOG WAS NOT INGESTED.\"\\\n",
-    "          \"\\nYou may either continue with the pre-existing catalog, or choose a new\"\\\n",
+    "    print(\"\\nNOTE THAT IF YOU SEE THIS MESSAGE, YOUR CATALOG WAS NOT INGESTED.\"\n",
+    "          \"\\nYou may either continue with the pre-existing catalog, or choose a new\"\n",
     "          \" name and re-run the previous cell and this one to ingest a new catalog.\")"
    ]
   },
@@ -621,7 +829,7 @@
    "outputs": [],
    "source": [
     "inject_config = VisitInjectConfig()\n",
-    "inject_config.stamp_prefix='data/'\n",
+    "inject_config.stamp_prefix = 'data/'\n",
     "\n",
     "inject_task = VisitInjectTask(config=inject_config)"
    ]


### PR DESCRIPTION
Added Section 3.2.2, which demonstrates how to rotate a postage stamp image before injecting it into a calexp. This is a question that has come up many times, so we wanted to show it in this notebook.