### PR TITLE
Add mobu config file to handle excluding directories

### DIFF
--- a/mobu.yaml
+++ b/mobu.yaml
@@ -1,0 +1,3 @@
+exclude_dirs:
+  - "DP02_09_Custom_Coadds"
+  - "DP02_11_User_Packages"


### PR DESCRIPTION
The newest version of mobu no longer honors the `exclude_dirs` key in the Phalanx config. To replace it, mobu will look for a `mobu.yaml` file in this repo, with an `exclude_dirs` key. This is nice because anyone with access to the repo can change which directories are excluded; you don't have to wait for someone to approve a Phalanx PR anymore.

This invalidates the instructions here, which I will change after I merge this:
https://confluence.lsstcorp.org/pages/viewpage.action?spaceKey=LSSTOps&title=How+to+exclude+a+tutorial+notebook+from+mobu

This is also described in the new [mobu
docs](https://mobu.lsst.io/user_guide/in_repo_config.html)!