### PR TITLE
Avoid doing a Butler write in DP02_14

### DIFF
--- a/DP02_14_Injecting_Synthetic_Sources.ipynb
+++ b/DP02_14_Injecting_Synthetic_Sources.ipynb
@@ -131,9 +131,8 @@
     "import lsst.afw.image as afwImage\n",
     "import lsst.afw.math as afwMath\n",
     "from lsst.daf.butler import Butler\n",
-    "from lsst.daf.butler.registry import ConflictingDefinitionError\n",
     "import lsst.geom as geom\n",
-    "from lsst.source.injection import ingest_injection_catalog, generate_injection_catalog\n",
+    "from lsst.source.injection import generate_injection_catalog\n",
     "from lsst.source.injection import VisitInjectConfig, VisitInjectTask\n",
     "from lsst.ip.diffim.subtractImages import AlardLuptonSubtractTask, AlardLuptonSubtractConfig"
    ]
@@ -349,7 +348,7 @@
    "id": "96734edf-8d93-49f3-8ac0-1149ae835a4b",
    "metadata": {},
    "source": [
-    "## 3. Make and ingest a catalog of synthetic sources:\n",
+    "## 3. Make a catalog of synthetic sources:\n",
     "\n",
     "Having retrieved a `calexp` image to inject into, now set up a simple synthetic source catalog.\n",
     "\n",
@@ -705,109 +704,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d9960aa-0c91-4752-a5d9-a58b51c16a82",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-12-15T23:16:55.956111Z",
-     "iopub.status.busy": "2023-12-15T23:16:55.955797Z",
-     "iopub.status.idle": "2023-12-15T23:16:55.959344Z",
-     "shell.execute_reply": "2023-12-15T23:16:55.958775Z",
-     "shell.execute_reply.started": "2023-12-15T23:16:55.956092Z"
-    }
-   },
-   "source": [
-    "### 3.3 Ingest the synthetic source catalog into a butler collection\n",
-    "\n",
-    "#### 3.3.1 Register the source injection collection\n",
-    "\n",
-    "The input `inject_cat` will be ingested into a collection called `u/{user}/test_injection_inputs` (where \"user\" will be the account username) in the butler repository. \n",
-    "\n",
-    "This demonstrates an alternate way to obtain a username (compared to the use of `getpass` demonstrated above)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5aa99d39-9f1f-4a98-af42-05d1010e5e8e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "user = os.getenv(\"USER\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8a0a1036-312a-479b-b15b-908a7643eab0",
-   "metadata": {},
-   "source": [
-    "Define the name of the collection.\n",
-    "\n",
-    "> Notice: If an attempt is made to inject synthetic sources into a collection that already exists, the task will complain that the output data already exist on disk. The name assigned to the collection in `INJECTION_CATALOG_COLLECTION` in the following cell must not have been used before. If it has been, choose a new name (or add a unique string, such as a timestamp like `_20240610_1600`, to the end of it) for each rerun."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "037b2281-dd1e-4c4d-a4de-0213c9bb9a92",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "INJECTION_CATALOG_COLLECTION = f\"u/{user}/test_injection_inputs_2\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1cb5c620-44da-4c72-be7a-cb1cf0e45b4d",
-   "metadata": {},
-   "source": [
-    "The collection must be registered in order to use it.\n",
-    "\n",
-    "Instantiate a writeable `butler`. Butlers are instantiated in read-only mode by default. By setting the argument `writeable` to `True`, a butler can also be made to be writeable.\n",
-    "\n",
-    "> Warning: take care when working with a writeable butler, as data on-disk has the potential to be permanently removed or corrupted."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "172a6e88-d605-438f-9fd0-4e39185be6cc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "writeable_butler = Butler(butler_config, writeable=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a8e3bbf6-d136-44b2-bd3b-8b243020acd8",
-   "metadata": {},
-   "source": [
-    "Now ingest the catalog of synthetic sources into the butler collection using the `ingest_injection_catalog` function:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "318fcb42-963c-4777-adeb-661cf7774194",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "    my_injected_datasetRefs = ingest_injection_catalog(\n",
-    "        writeable_butler=writeable_butler,\n",
-    "        table=inject_cat,\n",
-    "        band=\"g\",\n",
-    "        output_collection=INJECTION_CATALOG_COLLECTION,\n",
-    "    )\n",
-    "except ConflictingDefinitionError:\n",
-    "    print(f\"Found an existing collection named INJECTION_CATALOG_COLLECTION={INJECTION_CATALOG_COLLECTION}.\")\n",
-    "    print(\"\\nNOTE THAT IF YOU SEE THIS MESSAGE, YOUR CATALOG WAS NOT INGESTED.\"\n",
-    "          \"\\nYou may either continue with the pre-existing catalog, or choose a new\"\n",
-    "          \" name and re-run the previous cell and this one to ingest a new catalog.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "02faa0d1-dd40-4522-9812-6ec90485157e",
    "metadata": {},
    "source": [
@@ -815,7 +711,7 @@
     "\n",
     "### 4.1 Use source_injection tools to inject sources\n",
     "\n",
-    "The catalog specifying synthetic sources has been ingested into the butler. Now run the task from `source_injection` that injects sources into the `calexp` image that was retrieved earlier.\n",
+    "We made a catalog specifying the synthetic sources to inject. Now run the task from `source_injection` that injects sources into the `calexp` image that was retrieved earlier.\n",
     "\n",
     "First, extract the point spread function (PSF), photometric calibration object, and the WCS (World Coordinate System) object associated with the `calexp` image. These will be passed to the injection task so that sources can be injected using the properties of the image itself."
    ]
@@ -830,31 +726,6 @@
     "psf = calexp_g.getPsf()\n",
     "photo_calib = calexp_g.getPhotoCalib()\n",
     "wcs = calexp_g.getWcs()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4448cfb6-7444-44c1-90bc-d2bdabc2983f",
-   "metadata": {},
-   "source": [
-    "Load the input injection catalogs that were ingested into the butler in the previous step."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c39a1cf2-b95e-4627-9907-0c0ed6d609b5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "injection_refs = butler.registry.queryDatasets(\n",
-    "    \"injection_catalog\",\n",
-    "    band=\"g\",\n",
-    "    collections=INJECTION_CATALOG_COLLECTION,\n",
-    ")\n",
-    "injection_catalogs = [\n",
-    "    butler.get(injection_ref) for injection_ref in injection_refs\n",
-    "]"
    ]
   },
   {
@@ -929,7 +800,7 @@
    "outputs": [],
    "source": [
     "injected_output = inject_task.run(\n",
-    "    injection_catalogs=injection_catalogs,\n",
+    "    injection_catalogs=inject_cat,\n",
     "    input_exposure=calexp_g.clone(),\n",
     "    psf=psf,\n",
     "    photo_calib=photo_calib,\n",


### PR DESCRIPTION
Removed an unnecessary round-trip of the injection catalog through the Butler from tutorial DP02_14.  The ingestion of this catalog was effectively writing it and reading it back unchanged, so it isn't necessary.

We are about to transition DP02 to use client/server Butler.  Client/server Butler does not yet support writes, so it won't be able to run this tutorial without this change.