### PR TITLE
Use region searches instead of HTM IDs for DP02_04b

### DIFF
--- a/DP02_04b_Intermediate_Butler_Queries.ipynb
+++ b/DP02_04b_Intermediate_Butler_Queries.ipynb
@@ -1060,33 +1060,7 @@
    "source": [
     "#### 3.3.2. User-defined spatial constraints on images\n",
     "\n",
-    "Arbitrary spatial queries are not supported at this time, such as the \"POINT() IN (REGION)\" example found in this [Butler queries](https://pipelines.lsst.io/v/weekly/modules/lsst.daf.butler/queries.html) documentation.\n",
-    "In other words, at this time it is only possible to do queries involving regions that are already \"in\" the data repository, either because they are hierarchical triangular mesh (HTM) pixel regions or because they are tract/patch/visit/visit+detector regions.\n",
-    "\n",
-    "Thus, for this example we use the set of dimensions that correspond to different levels of the HTM pixelization of the sky ([HTM primer](http://www.skyserver.org/htm/)).\n",
-    "The process is to transform a region or point into one or more HTM identifiers (HTM IDs), and then create a query using the HTM ID as the spatial dataId.\n",
-    "The `lsst.sphgeom` library supports region objects and HTM pixelization in the LSST Science Pipelines.\n",
-    "\n",
-    "Using the `lsst.sphgeom` package, initialize a sky pixelization to level 10 (the level at which one sky pixel is about five arcmin radius)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "level = 10  # the resolution of the HTM grid\n",
-    "pixelization = lsst.sphgeom.HtmPixelization(level)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Find the HTM ID for a desired sky coordinate. Below, the RA and Dec could be user-specified, but here we use the telescope boresight accessed from the calexp visitInfo retrieved above."
+    "This example will use the `region OVERLAPS POINT()` example found in the [Butler queries](https://pipelines.lsst.io/v/weekly/modules/lsst.daf.butler/queries.html) documentation.  Below, the RA and Dec could be user-specified, but here we use the telescope boresight accessed from the calexp visitInfo retrieved above."
    ]
   },
   {
@@ -1098,42 +1072,8 @@
    "outputs": [],
    "source": [
     "ra, dec = visitInfo.boresightRaDec\n",
-    "htm_id = pixelization.index(\n",
-    "    lsst.sphgeom.UnitVector3d(\n",
-    "        lsst.sphgeom.LonLat.fromDegrees(ra.asDegrees(), dec.asDegrees())\n",
-    "    )\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Obtain and print the scale to provide a sense of the size of the sky pixelization being used. The opening angle for the circle is \"the angle between its center vector and points on its boundary\", i.e., the radius (from the [documentation for .getOpeningAngle in doxygen](http://doxygen.lsst.codes/stack/doxygen/x_masterDoxyDoc/classlsst_1_1sphgeom_1_1_circle.html#aa112ddd08e8445f67db9877a74d8a5c8))."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "circle = pixelization.triangle(htm_id).getBoundingCircle()\n",
-    "scale = circle.getOpeningAngle().asDegrees()*3600.\n",
-    "level = pixelization.getLevel()\n",
-    "print(f'HTM ID={htm_id} at level={level} is bounded by a circle of radius ~{scale:0.2f} arcsec.')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
+    "ra_degrees = ra.asDegrees()\n",
+    "dec_degrees = dec.asDegrees()\n",
     "small_timespan = dafButler.Timespan(time - minute, time + minute)"
    ]
   },
@@ -1141,7 +1081,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pass the htm_id to the queryDatasets command, and also apply the same timespan constraints as above."
+    "Pass the sky position to the queryDatasets command, and also apply the same timespan constraints as above."
    ]
   },
   {
@@ -1152,9 +1092,9 @@
    },
    "outputs": [],
    "source": [
-    "datasetRefs = registry.queryDatasets(\"calexp\", htm20=htm_id,\n",
-    "                                     where=\"visit.timespan OVERLAPS my_timespan\",\n",
-    "                                     bind={\"my_timespan\": small_timespan})\n",
+    "datasetRefs = registry.queryDatasets(\"calexp\",\n",
+    "                                     where=\"visit.timespan OVERLAPS my_timespan AND visit_detector_region.region OVERLAPS POINT(ra, dec)\",\n",
+    "                                     bind={\"my_timespan\": small_timespan, \"ra\": ra_degrees, \"dec\": dec_degrees})\n",
     "\n",
     "for i, ref in enumerate(datasetRefs):\n",
     "    print(ref)\n",
@@ -1171,9 +1111,7 @@
    "source": [
     "Thus, with the above query, we have *uniquely* recovered the visit for our desired temporal and spatial constraints.\n",
     "\n",
-    "Note that since we used the boresight as the RA, Dec for the `htm_id` and not the center of detector 175, a different detector (one in the center of the focal plane) has been returned - but the point here is that it is the same visit, 192350.\n",
-    "\n",
-    "Note that if a smaller HTM level is used (like 7), which is a larger sky pixel (~2200 arcseconds), the above query will return many more visits and detectors which overlap with that larger region. Try it and see!"
+    "Note that since we used the boresight as the RA/Dec and not the center of detector 175, a different detector (one in the center of the focal plane) has been returned - but the point here is that it is the same visit, 192350."
    ]
   },
   {
@@ -1232,10 +1170,10 @@
    "metadata": {},
    "source": [
     "The recommended method for querying and retrieving catalog data is to use the TAP service, as demonstrated in other tutorials.\n",
-    "However, it is also possible to query catalog data using the same HTM ID and same temporal constraints as used for images, above.\n",
+    "However, it is also possible to query catalog data using the same sky position and same temporal constraints as used for images, above.\n",
     "\n",
     "The Butler's spatial reasoning is designed to work well for regions the size of full data products, like detector- or patch-level images and catalogs, and it's a poor choice for smaller-scale searches.\n",
-    "The following search is a bit slow in part because `queryDatasets` searches for all `src` datasets that overlap a larger region and then filters the results down to the specified HTM ID pixel."
+    "The following search is a bit slow in part because `queryDatasets` searches for all `src` datasets that overlap a larger region and then filters the results down to the specified point."
    ]
   },
   {
@@ -1246,9 +1184,9 @@
    },
    "outputs": [],
    "source": [
-    "for i, src_ref in enumerate(registry.queryDatasets(\"source\", htm20=htm_id, band=\"i\",\n",
-    "                                                   where=\"visit.timespan OVERLAPS my_timespan\",\n",
-    "                                                   bind={\"my_timespan\": small_timespan})):\n",
+    "for i, src_ref in enumerate(registry.queryDatasets(\"source\", band=\"i\",\n",
+    "                                                   where=\"visit.timespan OVERLAPS my_timespan AND visit_detector_region.region OVERLAPS POINT(ra, dec)\",\n",
+    "                                                   bind={\"my_timespan\": small_timespan, \"ra\": ra_degrees, \"dec\": dec_degrees})):\n",
     "    print(src_ref)\n",
     "    sources = butler.get(src_ref)\n",
     "    print('Number of sources: ', len(sources))\n",


### PR DESCRIPTION
The latest version of client/server Butler now supports arbitrary region searches, instead of requiring users to manually figure out the HTM pixelization IDs.  The examples of spatial searches in DP02_04b have been updated to use the `POINT()` syntax.