### PR TITLE
Add config override in NB14

### DIFF
--- a/DP02_14_Injecting_Synthetic_Sources.ipynb
+++ b/DP02_14_Injecting_Synthetic_Sources.ipynb
@@ -915,7 +915,7 @@
     "\n",
     "The first two lines below load the default configuration for the `AlardLuptonSubtract` task, and then initialize the task with that configuration. The task requires (1) a template exposure, (2) the science exposure, and (3) the catalog of sources from the science exposure.\n",
     "\n",
-    "Load the source catalog (`src`) and run the task."
+    "Load the source catalog (`src`) and run the task. Override the default configuration to point the \"sourceSelector\" to \"base_ClassificationExtendedness_value.\""
    ]
   },
   {
@@ -926,6 +926,7 @@
    "outputs": [],
    "source": [
     "config = AlardLuptonSubtractConfig()\n",
+    "config.sourceSelector.value.unresolved.name = 'base_ClassificationExtendedness_value'\n",
     "alTask = AlardLuptonSubtractTask(config=config)\n",
     "\n",
     "scienceExposure = injected_exposure\n",


### PR DESCRIPTION
Changes in ip_diffim in w_38 of the pipelines broke the source injection notebook, because the default column for point-source selection was pointing to a value that isn't present in DP0.2. Added an override to instead use the value that _is_ present.