### PR TITLE
Add try/except to fix NB14

### DIFF
--- a/DP02_14_Injecting_Synthetic_Sources.ipynb
+++ b/DP02_14_Injecting_Synthetic_Sources.ipynb
@@ -919,6 +919,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "5ddb4207-6ee0-4687-b7f9-df9e1c1db690",
+   "metadata": {},
+   "source": [
+    "As of w_2024_38, the source selector within `AlardLuptonSubtractTask` has been changed. In the new selector, the default value that is used does not exist in DP0.2 catalogs, so we need to override the configured value to use base_ClassificationExtendedness_value instead. However, that override will fail on all pipeline versions prior to w_38, so we wrap it in a try:except block so that this cell will run with any pipelines version."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "03039124-03de-49b3-b998-e59ae1a74a7f",
@@ -926,7 +934,11 @@
    "outputs": [],
    "source": [
     "config = AlardLuptonSubtractConfig()\n",
-    "config.sourceSelector.value.unresolved.name = 'base_ClassificationExtendedness_value'\n",
+    "try:\n",
+    "    config.sourceSelector.value.unresolved.name = 'base_ClassificationExtendedness_value'\n",
+    "except:\n",
+    "    pass\n",
+    "\n",
     "alTask = AlardLuptonSubtractTask(config=config)\n",
     "\n",
     "scienceExposure = injected_exposure\n",


### PR DESCRIPTION
A new source selector introduced to AlardLuptonSubtractTask in w_38 caused DP02_14 to fail. Added a try/except block to detect and update the config that needs to be changed if the weekly is w_2024_38 or newer, and to skip that for older versions.