### PR TITLE
DM-49188: Raise SodaQuery exceptions during execute_stream rather than silently failing

### DIFF
--- a/DP02_13a_Image_Cutout_SciDemo.ipynb
+++ b/DP02_13a_Image_Cutout_SciDemo.ipynb
@@ -353,8 +353,10 @@
     "    else:\n",
     "        sodaCutout = os.path.join(os.getenv('HOME'), tempdir+'cutout.fits')\n",
     "\n",
+    "    response_stream = sq.execute_stream()\n",
+    "    sq.raise_if_error()\n",
     "    with open(sodaCutout, 'bw') as f:\n",
-    "        f.write(sq.execute_stream().read())\n",
+    "        f.write(response_stream.read())\n",
     "\n",
     "    return sodaCutout"
    ]
@@ -688,8 +690,10 @@
    "outputs": [],
    "source": [
     "sodaCutout = os.path.join(os.getenv('HOME'), tempdir + '/cutout-circle.fits')\n",
+    "response_stream = sq.execute_stream()\n",
+    "sq.raise_if_error()\n",
     "with open(sodaCutout, 'bw') as f:\n",
-    "    f.write(sq.execute_stream().read())"
+    "    f.write(response_stream.read())"
    ]
   },
   {
@@ -771,8 +775,10 @@
     "               spherePoint.getDec().asDegrees() * u.deg + sphereRadius2)\n",
     "\n",
     "sodaCutout2 = os.path.join(os.getenv('HOME'), tempdir + '/cutout-polygon.fits')\n",
+    "response_stream = sq2.execute_stream()\n",
+    "sq2.raise_if_error()\n",
     "with open(sodaCutout2, 'bw') as f:\n",
-    "    f.write(sq2.execute_stream().read())\n",
+    "    f.write(response_stream.read())\n",
     "\n",
     "plotImage(ExposureF(sodaCutout2))"
    ]


### PR DESCRIPTION
## Description of issue

In the Image cutout notebook (`DP02_13a_Image_Cutout_SciDemo`) in the case where the `SodaQuery` (call to the` /cutout `api) fails, this will fail silently, as the exceptions are not propagated from the execute_stream call. This means that the notebook execution will continue, leading to the write method to write out the response of the 500 Error rather than an actual fits file. This in turn, will lead to a not very meaningful message later in the notebook.

## Fix

To address the issue, this PR uses the `raise_if_error` method of the `SodaQuery` object, which will raise any exceptions encountered during the execute_stream method execution. This should fail in a more meaningful way for the user


## How to test out a failed SodaQuery

To test out what this looks like in the case where the SodaQuery fails with an HTTP 500 error, you can try setting
`sq._baseurl = "httpstat.us/500" `
before the call to execute_stream. This should produce a more meaningful stack trace, showing that there was an HTTP 500 error during the execute_stream method

